### PR TITLE
feat: severity donut chart and clickable CVE/CWE links in reports

### DIFF
--- a/app/services/report_generators/markdown_report.rb
+++ b/app/services/report_generators/markdown_report.rb
@@ -114,7 +114,7 @@ module ReportGenerators
       lines << ''
 
       @findings.each_with_index do |f, idx|
-        cwe = f.cwe_id.present? ? " | #{f.cwe_id}" : ''
+        cwe = f.cwe_id.present? ? " | [#{f.cwe_id}](https://cwe.mitre.org/data/definitions/#{f.cwe_id.to_s.delete_prefix('CWE-')}.html)" : ''
         lines << "#{idx + 1}. **#{f.severity.upcase}** — #{f.title}"
         lines << "   - URL: #{f.url}" if f.url.present?
         lines << "   - Tool: #{f.source_tool}#{cwe}"
@@ -140,8 +140,8 @@ module ReportGenerators
         lines << "| URL | `#{f.url}` |" if f.url.present?
         lines << "| Tool | #{f.source_tool} |"
         lines << "| Parameter | `#{f.parameter}` |" if f.parameter.present?
-        lines << "| CWE | CWE-#{f.cwe_id} |" if f.cwe_id.present?
-        lines << "| CVE | #{f.cve_id} |" if f.cve_id.present?
+        lines << "| CWE | [#{f.cwe_id}](https://cwe.mitre.org/data/definitions/#{f.cwe_id.to_s.delete_prefix('CWE-')}.html) |" if f.cwe_id.present?
+        lines << "| CVE | [#{f.cve_id}](https://nvd.nist.gov/vuln/detail/#{f.cve_id}) |" if f.cve_id.present?
         lines << "| CVSS | #{f.cvss_score} |" if f.cvss_score.present?
         lines << "| EPSS | #{format_epss(f.epss_score)} |" if f.epss_score.present?
         if f.kev_known_exploited

--- a/app/services/report_generators/pdf_report.rb
+++ b/app/services/report_generators/pdf_report.rb
@@ -54,6 +54,9 @@ module ReportGenerators
       template = Rails.root.join('config/report_templates/pentest_report.latex')
       date = @scan.completed_at&.strftime('%B %d, %Y') || Time.current.strftime('%B %d, %Y')
 
+      summary = @scan.summary || {}
+      sev = summary['by_severity'] || {}
+
       args = [
         'pandoc', md_path,
         '-o', pdf_path,
@@ -65,7 +68,13 @@ module ReportGenerators
         '-V', 'fontsize=11pt',
         '--highlight-style=tango',
         '-V', "title=#{@target.name}",
-        '-V', "date=#{date}"
+        '-V', "date=#{date}",
+        '-V', "sev_critical=#{sev['critical'].to_i}",
+        '-V', "sev_high=#{sev['high'].to_i}",
+        '-V', "sev_medium=#{sev['medium'].to_i}",
+        '-V', "sev_low=#{sev['low'].to_i}",
+        '-V', "sev_info=#{sev['info'].to_i}",
+        '-V', "sev_total=#{summary['total_findings'].to_i}"
       ]
 
       args.shelljoin

--- a/config/report_templates/pentest_report.latex
+++ b/config/report_templates/pentest_report.latex
@@ -242,6 +242,94 @@ $endif$
 \clearpage
 
 % ============================================================
+% SEVERITY DISTRIBUTION CHART
+% ============================================================
+\ifnum$sev_total$>0
+
+\thispagestyle{fancy}
+
+\begin{center}
+{\color{brand-navy}\LARGE\bfseries Severity Distribution}
+\vspace{0.5em}
+
+{\color{brand-accent}\rule{\textwidth}{2pt}}
+\end{center}
+
+\vspace{1.5em}
+
+\newcount\sevtotal
+\sevtotal=$sev_total$
+
+\begin{center}
+\begin{tikzpicture}[scale=1.0]
+  % Calculate angles
+  \pgfmathsetmacro{\acrit}{$sev_critical$ / $sev_total$ * 360}
+  \pgfmathsetmacro{\ahigh}{$sev_high$ / $sev_total$ * 360}
+  \pgfmathsetmacro{\amed}{$sev_medium$ / $sev_total$ * 360}
+  \pgfmathsetmacro{\alow}{$sev_low$ / $sev_total$ * 360}
+  \pgfmathsetmacro{\ainfo}{$sev_info$ / $sev_total$ * 360}
+
+  % Starting angles
+  \pgfmathsetmacro{\startA}{90}
+  \pgfmathsetmacro{\startB}{\startA - \acrit}
+  \pgfmathsetmacro{\startC}{\startB - \ahigh}
+  \pgfmathsetmacro{\startD}{\startC - \amed}
+  \pgfmathsetmacro{\startE}{\startD - \alow}
+
+  % Draw pie slices (only if > 0)
+  \ifnum$sev_critical$>0
+    \fill[sev-critical] (0,0) -- (\startA:3) arc (\startA:\startB:3) -- cycle;
+  \fi
+  \ifnum$sev_high$>0
+    \fill[sev-high] (0,0) -- (\startB:3) arc (\startB:\startC:3) -- cycle;
+  \fi
+  \ifnum$sev_medium$>0
+    \fill[sev-medium] (0,0) -- (\startC:3) arc (\startC:\startD:3) -- cycle;
+  \fi
+  \ifnum$sev_low$>0
+    \fill[sev-low] (0,0) -- (\startD:3) arc (\startD:\startE:3) -- cycle;
+  \fi
+  \ifnum$sev_info$>0
+    \fill[sev-info] (0,0) -- (\startE:3) arc (\startE:\startA-360:3) -- cycle;
+  \fi
+
+  % White center circle (donut)
+  \fill[white] (0,0) circle (1.5);
+
+  % Total count in center
+  \node[font=\fontsize{28}{32}\selectfont\bfseries, text=brand-navy] at (0,0.2) {$sev_total$};
+  \node[font=\small, text=brand-slate] at (0,-0.4) {findings};
+
+\end{tikzpicture}
+\end{center}
+
+\vspace{1.5em}
+
+% Legend
+\begin{center}
+\begin{tabular}{clc clc clc clc clc}
+  \ifnum$sev_critical$>0
+    \textcolor{sev-critical}{\rule{12pt}{12pt}} & \small\textbf{Critical} & \small $sev_critical$ &
+  \fi
+  \ifnum$sev_high$>0
+    \textcolor{sev-high}{\rule{12pt}{12pt}} & \small\textbf{High} & \small $sev_high$ &
+  \fi
+  \ifnum$sev_medium$>0
+    \textcolor{sev-medium}{\rule{12pt}{12pt}} & \small\textbf{Medium} & \small $sev_medium$ &
+  \fi
+  \ifnum$sev_low$>0
+    \textcolor{sev-low}{\rule{12pt}{12pt}} & \small\textbf{Low} & \small $sev_low$ &
+  \fi
+  \ifnum$sev_info$>0
+    \textcolor{sev-info}{\rule{12pt}{12pt}} & \small\textbf{Info} & \small $sev_info$
+  \fi
+\end{tabular}
+\end{center}
+
+\clearpage
+\fi
+
+% ============================================================
 % DOCUMENT BODY
 % ============================================================
 


### PR DESCRIPTION
## Summary
- TikZ donut chart on dedicated page after TOC showing severity distribution with color legend
- CWE IDs linked to cwe.mitre.org, CVE IDs linked to nvd.nist.gov — clickable in PDF
- Chart skipped when 0 findings

Closes #35

## Test plan
- [x] PDF renders with donut chart (tested with 42 findings across 5 severities)
- [x] Chart skipped when sev_total=0
- [x] CWE/CVE links render as clickable blue text in PDF

🤖 Generated with [Claude Code](https://claude.com/claude-code)