### PR TITLE
fix: scan VMs internet access and self-terminate on failure (#133)

### DIFF
--- a/.buildkite/scripts/trigger-scan.sh
+++ b/.buildkite/scripts/trigger-scan.sh
@@ -59,7 +59,6 @@ gcloud compute instances create "${VM_NAME}" \
   --metadata-from-file=startup-script="${STARTUP_SCRIPT}" \
   --tags=pentest-scan \
   --labels="env=${ENV},project=pentest,scan=true" \
-  --no-address \
   ${SPOT_FLAG} \
   --quiet
 

--- a/cloud/lib/scan-vm.sh
+++ b/cloud/lib/scan-vm.sh
@@ -64,7 +64,6 @@ gcloud compute instances create "${VM_SCAN_NAME}" \
   --metadata-from-file=startup-script="${CLOUD_DIR}/lib/vm-startup.sh" \
   --tags=pentest-scan \
   --labels="env=${ENV},project=pentest,scan=true" \
-  --no-address \
   ${SPOT_FLAG} \
   --quiet
 

--- a/cloud/lib/vm-startup.sh
+++ b/cloud/lib/vm-startup.sh
@@ -20,6 +20,20 @@ PROJECT_ID=$(curl -sf -H "$METADATA_HEADER" "${METADATA_URL}/project/project-id"
 ZONE=$(curl -sf -H "$METADATA_HEADER" "${METADATA_URL}/instance/zone" | cut -d'/' -f4)
 INSTANCE_NAME=$(curl -sf -H "$METADATA_HEADER" "${METADATA_URL}/instance/name")
 
+# Self-terminate on failure for scan VMs (prevents orphaned VMs incurring cost)
+self_terminate() {
+  echo "=== Self-terminating VM ${INSTANCE_NAME} ==="
+  sleep 5
+  gcloud compute instances delete "${INSTANCE_NAME}" \
+    --zone="${ZONE}" \
+    --project="${PROJECT_ID}" \
+    --quiet 2>/dev/null || true
+}
+
+if [ "$SCAN_MODE" != "dev" ]; then
+  trap self_terminate EXIT
+fi
+
 echo "=== Pentest VM Startup (mode: ${SCAN_MODE}) ==="
 
 # --- Common: Install Docker if missing ---
@@ -122,13 +136,7 @@ case "$SCAN_MODE" in
       gsutil -m cp -r "${RESULTS_DIR}/*" "gs://${GCS_BUCKET}/vm-results/${INSTANCE_NAME}/" 2>/dev/null || true
     fi
 
-    # Self-terminate
-    echo "=== Scan complete — self-terminating ==="
-    sleep 5
-    gcloud compute instances delete "${INSTANCE_NAME}" \
-      --zone="${ZONE}" \
-      --project="${PROJECT_ID}" \
-      --quiet
+    # Self-termination handled by EXIT trap
     ;;
 
   *)

--- a/cloud/scheduler/main.py
+++ b/cloud/scheduler/main.py
@@ -42,6 +42,10 @@ def trigger_scan(request):
         )],
         network_interfaces=[compute_v1.NetworkInterface(
             name='global/networks/default',
+            access_configs=[compute_v1.AccessConfig(
+                name='External NAT',
+                type_='ONE_TO_ONE_NAT',
+            )],
         )],
         service_accounts=[compute_v1.ServiceAccount(
             email=SERVICE_ACCOUNT,

--- a/cloud/scheduler/vm-startup.sh
+++ b/cloud/scheduler/vm-startup.sh
@@ -20,6 +20,20 @@ PROJECT_ID=$(curl -sf -H "$METADATA_HEADER" "${METADATA_URL}/project/project-id"
 ZONE=$(curl -sf -H "$METADATA_HEADER" "${METADATA_URL}/instance/zone" | cut -d'/' -f4)
 INSTANCE_NAME=$(curl -sf -H "$METADATA_HEADER" "${METADATA_URL}/instance/name")
 
+# Self-terminate on failure for scan VMs (prevents orphaned VMs incurring cost)
+self_terminate() {
+  echo "=== Self-terminating VM ${INSTANCE_NAME} ==="
+  sleep 5
+  gcloud compute instances delete "${INSTANCE_NAME}" \
+    --zone="${ZONE}" \
+    --project="${PROJECT_ID}" \
+    --quiet 2>/dev/null || true
+}
+
+if [ "$SCAN_MODE" != "dev" ]; then
+  trap self_terminate EXIT
+fi
+
 echo "=== Pentest VM Startup (mode: ${SCAN_MODE}) ==="
 
 # --- Common: Install Docker if missing ---
@@ -122,13 +136,7 @@ case "$SCAN_MODE" in
       gsutil -m cp -r "${RESULTS_DIR}/*" "gs://${GCS_BUCKET}/vm-results/${INSTANCE_NAME}/" 2>/dev/null || true
     fi
 
-    # Self-terminate
-    echo "=== Scan complete — self-terminating ==="
-    sleep 5
-    gcloud compute instances delete "${INSTANCE_NAME}" \
-      --zone="${ZONE}" \
-      --project="${PROJECT_ID}" \
-      --quiet
+    # Self-termination handled by EXIT trap
     ;;
 
   *)

--- a/spec/cloud/scan_vm_internet_access_spec.rb
+++ b/spec/cloud/scan_vm_internet_access_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+RSpec.describe 'scan VM internet access' do # rubocop:disable RSpec/DescribeClass
+  let(:project_root) { File.expand_path('../..', __dir__) }
+
+  describe 'trigger-scan.sh' do
+    let(:script) { File.read(File.join(project_root, '.buildkite/scripts/trigger-scan.sh')) }
+
+    it 'does not use --no-address flag' do
+      expect(script).not_to include('--no-address')
+    end
+
+    it 'creates VM with gcloud compute instances create' do
+      expect(script).to include('gcloud compute instances create')
+    end
+  end
+
+  describe 'scan-vm.sh' do
+    let(:script) { File.read(File.join(project_root, 'cloud/lib/scan-vm.sh')) }
+
+    it 'does not use --no-address flag' do
+      expect(script).not_to include('--no-address')
+    end
+  end
+
+  describe 'cloud/scheduler/main.py' do
+    let(:script) { File.read(File.join(project_root, 'cloud/scheduler/main.py')) }
+
+    it 'configures an access config for external IP on network interface' do
+      expect(script).to include('AccessConfig')
+    end
+  end
+
+  describe 'vm-startup.sh (lib)' do
+    let(:script) { File.read(File.join(project_root, 'cloud/lib/vm-startup.sh')) }
+
+    it 'has a trap for self-termination on failure' do
+      expect(script).to match(/trap\b.*self_terminate/)
+    end
+
+    it 'defines a self_terminate function' do
+      expect(script).to match(/self_terminate\(\)/)
+    end
+  end
+
+  describe 'vm-startup.sh (scheduler)' do
+    let(:script) { File.read(File.join(project_root, 'cloud/scheduler/vm-startup.sh')) }
+
+    it 'has a trap for self-termination on failure' do
+      expect(script).to match(/trap\b.*self_terminate/)
+    end
+
+    it 'defines a self_terminate function' do
+      expect(script).to match(/self_terminate\(\)/)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- **Removed `--no-address`** from `trigger-scan.sh` and `scan-vm.sh` — ephemeral scan VMs now get external IPs for outbound internet access
- **Added `access_configs`** to Cloud Function `main.py` — the Python SDK creates VMs without external IPs by default unless explicitly configured
- **Added EXIT trap** to both copies of `vm-startup.sh` — scan VMs now self-terminate even if the startup script fails early (Docker install, image pull, etc.), preventing orphaned VMs incurring cost

Closes #133

## Root cause
`--no-address` creates VMs without external IPs. Without Cloud NAT on the VPC, these VMs have zero outbound internet. Docker install fails, image pull fails, scan can't reach targets, and `set -e` exits before the self-terminate code runs. Build #37 staging scan failed for this reason.

## Test plan
- [ ] 8 RSpec specs validate fixes across all affected files
- [ ] Trigger a staging scan via Buildkite and verify it completes end-to-end
- [ ] Verify VM self-terminates after scan (check with `gcloud compute instances list`)
- [ ] Simulate startup failure: verify VM still self-terminates via the EXIT trap

🤖 Generated with [Claude Code](https://claude.com/claude-code)