### PR TITLE
refactor: Add gcs_scan_results_path to callback (#240)

### DIFF
--- a/app/services/scan_callback_service.rb
+++ b/app/services/scan_callback_service.rb
@@ -4,9 +4,10 @@ class ScanCallbackService
   MAX_RETRIES = 3
   RETRY_BASE_DELAY = 0.5
 
-  def initialize(scan, cost_logger)
+  def initialize(scan, cost_logger, gcs_scan_results_path: nil)
     @scan = scan
     @cost_logger = cost_logger
+    @gcs_scan_results_path = gcs_scan_results_path
   end
 
   def notify
@@ -23,14 +24,16 @@ class ScanCallbackService
   private
 
   def build_payload
-    {
+    payload = {
       scan_uuid: ENV.fetch('SCAN_UUID', @scan.id),
       status: @scan.status,
       duration_seconds: @scan.duration&.to_i,
       summary: @scan.summary || {},
+      gcs_scan_results_path: @gcs_scan_results_path,
       gcs_report_paths: report_paths,
       cost_data: @cost_logger.cost_data
     }
+    payload.compact
   end
 
   def report_paths

--- a/spec/services/scan_callback_service_spec.rb
+++ b/spec/services/scan_callback_service_spec.rb
@@ -140,6 +140,31 @@ RSpec.describe ScanCallbackService do
       expect(WebMock).not_to have_requested(:post, callback_url)
     end
 
+    it 'includes gcs_scan_results_path when provided' do
+      stub_request(:post, callback_url).to_return(status: 200, body: '{"ok":true}')
+      gcs_path = 'scan-results/target-1/scan-1/scan_results.json'
+
+      service = described_class.new(scan, cost_logger, gcs_scan_results_path: gcs_path)
+      service.notify
+
+      expect(WebMock).to(have_requested(:post, callback_url).with do |req|
+        body = JSON.parse(req.body)
+        body['gcs_scan_results_path'] == gcs_path
+      end)
+    end
+
+    it 'omits gcs_scan_results_path when not provided' do
+      stub_request(:post, callback_url).to_return(status: 200, body: '{"ok":true}')
+
+      service = described_class.new(scan, cost_logger)
+      service.notify
+
+      expect(WebMock).to(have_requested(:post, callback_url).with do |req|
+        body = JSON.parse(req.body)
+        !body.key?('gcs_scan_results_path')
+      end)
+    end
+
     it 'includes scan duration in the payload' do
       stub_request(:post, callback_url).to_return(status: 200, body: '{"ok":true}')
 


### PR DESCRIPTION
## Summary

- Adds optional `gcs_scan_results_path` parameter to `ScanCallbackService`
- Backend receives the GCS path of the versioned scan results JSON so it can trigger the reporter
- Backward compatible: field omitted from payload when not provided
- Payload uses `.compact` to strip nil values

**Chained from:** PR #249 (BigQueryLogger JSON-first)

## Test plan

- [x] 15 RSpec examples, 0 failures
- [x] Full suite: 529 examples, 0 failures, 94.94% coverage

Closes #240

🤖 Generated with [Claude Code](https://claude.com/claude-code)