### PR TITLE
refactor: scan.rake JSON-first pipeline (#241)

### DIFF
--- a/lib/tasks/scan.rake
+++ b/lib/tasks/scan.rake
@@ -34,7 +34,7 @@ namespace :scan do
       CveIntelligenceService.new.enrich_scan(scan)
     end
 
-    # AI Analysis (if API key configured)
+    # AI Analysis (if API key configured) — will move to reporter
     if ENV['ANTHROPIC_API_KEY'].present?
       puts "\n--- AI Analysis ---"
       AiAnalyzer.new.analyze_scan(scan)
@@ -47,19 +47,25 @@ namespace :scan do
       puts "  Created #{created} tickets"
     end
 
-    # Generate reports
+    # Export versioned JSON to GCS (canonical scan output)
+    puts "\n--- Scan Results Export ---"
+    gcs_scan_results_path = ScanResultsExporter.new(scan).export
+    puts "  Exported v#{ScanResultsExporter::SCHEMA_VERSION} to #{gcs_scan_results_path}"
+
+    # Load findings to BigQuery FROM the versioned JSON
+    if BigQueryLogger.enabled?
+      puts "\n--- Finding History (JSON-first) ---"
+      scan_results = ScanResultsExporter.new(scan).build_envelope
+      logged = BigQueryLogger.new.log_from_json(scan_results)
+      puts "  Logged #{logged} findings to BigQuery (#{ENV.fetch('SCAN_MODE', 'dev')})"
+    end
+
+    # Generate reports — kept during transition, will move to reporter
     puts "\n--- Report Generation ---"
     generator = ReportGenerator.new(scan)
     reports = generator.generate_all
     reports.each do |report|
       puts "  #{report.format.upcase}: #{report.gcs_path || 'local'} (#{report.status})"
-    end
-
-    # Log findings to BigQuery
-    if BigQueryLogger.enabled?
-      puts "\n--- Finding History ---"
-      logged = BigQueryLogger.new.log_findings(scan)
-      puts "  Logged #{logged} findings to BigQuery (#{ENV.fetch('SCAN_MODE', 'dev')})"
     end
 
     # Log scan costs to BigQuery
@@ -74,10 +80,10 @@ namespace :scan do
       end
     end
 
-    # Callback to backend API
+    # Callback to backend API (now includes GCS scan results path)
     if ScanCallbackService.enabled?
       puts "\n--- Backend Callback ---"
-      if ScanCallbackService.new(scan, cost_logger).notify
+      if ScanCallbackService.new(scan, cost_logger, gcs_scan_results_path:).notify
         puts "  Callback sent to #{ENV.fetch('CALLBACK_URL', 'unknown')}"
       else
         puts '  Callback failed (scan still succeeded)'


### PR DESCRIPTION
## Summary

- Reorders scan pipeline: JSON export to GCS happens before BQ loading
- BQ now loaded from the versioned JSON envelope (not ActiveRecord)
- Callback includes `gcs_scan_results_path` so backend can trigger reporter
- Report generation kept during transition (marked for future removal)
- AI analysis kept during transition (marked for future removal)

**Chained from:** PR #250 (ScanCallbackService)

## Test plan

- [x] Full suite: 529 examples, 0 failures
- [ ] End-to-end scan with BQ + GCS in staging

Closes #241

🤖 Generated with [Claude Code](https://claude.com/claude-code)