### PR TITLE
compliance: 18-month data retention policy (#242)

### DIFF
--- a/app/services/data_retention_purger.rb
+++ b/app/services/data_retention_purger.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require 'google/cloud/bigquery'
+
+class DataRetentionPurger
+  RETENTION_MONTHS = 18
+  DATASET_ID = 'pentest_history'.freeze
+  AUDIT_DATASET_ID = 'audit_logs'.freeze
+
+  PURGEABLE_TABLES = {
+    'scan_findings' => { date_column: 'scan_date', dataset: DATASET_ID },
+    'scan_metadata' => { date_column: 'scan_date', dataset: DATASET_ID },
+    'scan_costs' => { date_column: 'logged_at', dataset: DATASET_ID }
+  }.freeze
+
+  AUDIT_TABLES = {
+    'penetrator_events' => { date_column: 'timestamp', dataset: AUDIT_DATASET_ID }
+  }.freeze
+
+  def initialize
+    @client = Google::Cloud::Bigquery.new
+    @scan_mode = ENV.fetch('SCAN_MODE', 'dev')
+    @cutoff = Time.now.utc - (RETENTION_MONTHS * 30.44 * 24 * 3600)
+  end
+
+  def purge_all
+    results = {}
+
+    all_tables.each do |base_name, config|
+      table_name = resolve_table_name(base_name)
+      results[table_name] = purge_table(config[:dataset], table_name, config[:date_column])
+    end
+
+    log_purge_event(results)
+    results
+  end
+
+  def preview_all
+    counts = {}
+
+    all_tables.each do |base_name, config|
+      table_name = resolve_table_name(base_name)
+      counts[table_name] = count_purgeable(config[:dataset], table_name, config[:date_column])
+    end
+
+    counts
+  end
+
+  private
+
+  def all_tables
+    PURGEABLE_TABLES.merge(AUDIT_TABLES)
+  end
+
+  def resolve_table_name(base_name)
+    return base_name if AUDIT_TABLES.key?(base_name)
+
+    "#{base_name}_#{@scan_mode}"
+  end
+
+  def purge_table(dataset_id, table_name, date_column)
+    dataset = @client.dataset(dataset_id)
+    return { success: true, rows_deleted: 0 } unless dataset&.table(table_name)
+
+    cutoff_str = @cutoff.strftime('%Y-%m-%d %H:%M:%S UTC')
+    sql = "DELETE FROM `#{dataset_id}.#{table_name}` WHERE #{date_column} < '#{cutoff_str}'"
+    result = @client.query(sql)
+    rows_deleted = result.total || 0
+
+    Rails.logger.info("[DataRetentionPurger] Purged #{rows_deleted} rows from #{table_name}")
+    { success: true, rows_deleted: rows_deleted }
+  rescue StandardError => e
+    Rails.logger.error("[DataRetentionPurger] Failed to purge #{table_name}: #{e.message}")
+    { success: false, rows_deleted: 0, error: e.message }
+  end
+
+  def count_purgeable(dataset_id, table_name, date_column)
+    dataset = @client.dataset(dataset_id)
+    return 0 unless dataset&.table(table_name)
+
+    cutoff_str = @cutoff.strftime('%Y-%m-%d %H:%M:%S UTC')
+    sql = "SELECT COUNT(*) AS cnt FROM `#{dataset_id}.#{table_name}` WHERE #{date_column} < '#{cutoff_str}'"
+    result = @client.query(sql)
+    result.first[:cnt]
+  rescue StandardError => e
+    Rails.logger.error("[DataRetentionPurger] Preview failed for #{table_name}: #{e.message}")
+    -1
+  end
+
+  def log_purge_event(results)
+    Rails.logger.info(
+      {
+        event: 'data_retention_purge',
+        timestamp: Time.now.utc.iso8601,
+        retention_months: RETENTION_MONTHS,
+        cutoff_date: @cutoff.iso8601,
+        results: results.transform_values { |r| { rows_deleted: r[:rows_deleted], success: r[:success] } }
+      }.to_json
+    )
+  end
+end

--- a/lib/tasks/retention.rake
+++ b/lib/tasks/retention.rake
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+namespace :retention do
+  desc 'Purge BigQuery data older than 18 months (data retention policy)'
+  task purge: :environment do
+    unless BigQueryLogger.enabled?
+      puts 'BigQuery not configured — skipping retention purge'
+      exit 0
+    end
+
+    purger = DataRetentionPurger.new
+    results = purger.purge_all
+
+    results.each do |table, result|
+      if result[:success]
+        puts "  #{table}: purged #{result[:rows_deleted]} rows"
+      else
+        puts "  #{table}: FAILED — #{result[:error]}"
+      end
+    end
+
+    puts "\nRetention purge complete at #{Time.current.iso8601}"
+  end
+
+  desc 'Dry run — show what would be purged without deleting'
+  task dry_run: :environment do
+    unless BigQueryLogger.enabled?
+      puts 'BigQuery not configured'
+      exit 0
+    end
+
+    purger = DataRetentionPurger.new
+    counts = purger.preview_all
+
+    counts.each do |table, count|
+      puts "  #{table}: #{count} rows older than 18 months"
+    end
+  end
+end

--- a/spec/services/data_retention_purger_spec.rb
+++ b/spec/services/data_retention_purger_spec.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DataRetentionPurger do
+  let(:mock_bigquery) { instance_double(Google::Cloud::Bigquery::Project) }
+  let(:mock_dataset) { instance_double(Google::Cloud::Bigquery::Dataset) }
+  let(:mock_table) { instance_double(Google::Cloud::Bigquery::Table) }
+
+  before do
+    allow(Google::Cloud::Bigquery).to receive(:new).and_return(mock_bigquery)
+    stub_const('ENV', ENV.to_h.merge('SCAN_MODE' => 'dev'))
+  end
+
+  describe '#purge_all' do
+    let(:query_result) { instance_double(Google::Cloud::Bigquery::Data, total: 42) }
+
+    before do
+      allow(mock_bigquery).to receive(:dataset).and_return(mock_dataset)
+      allow(mock_dataset).to receive(:table).and_return(mock_table)
+      allow(mock_bigquery).to receive(:query).and_return(query_result)
+    end
+
+    it 'purges all configured tables' do
+      results = described_class.new.purge_all
+
+      expect(results.keys).to include('scan_findings_dev', 'scan_metadata_dev', 'scan_costs_dev', 'penetrator_events')
+    end
+
+    it 'returns success with row counts' do
+      results = described_class.new.purge_all
+
+      results.each_value do |result|
+        expect(result[:success]).to be true
+        expect(result[:rows_deleted]).to eq(42)
+      end
+    end
+
+    it 'uses DELETE query with 18-month cutoff' do
+      expect(mock_bigquery).to receive(:query).with(/DELETE FROM.*WHERE.*scan_date </).at_least(:once).and_return(query_result)
+
+      described_class.new.purge_all
+    end
+
+    it 'logs the purge event' do
+      allow(Rails.logger).to receive(:info)
+      described_class.new.purge_all
+      expect(Rails.logger).to have_received(:info).with(/data_retention_purge/).once
+    end
+  end
+
+  describe '#purge_all when table does not exist' do
+    before do
+      allow(mock_bigquery).to receive(:dataset).and_return(mock_dataset)
+      allow(mock_dataset).to receive(:table).and_return(nil)
+    end
+
+    it 'returns zero rows deleted without error' do
+      results = described_class.new.purge_all
+
+      results.each_value do |result|
+        expect(result[:success]).to be true
+        expect(result[:rows_deleted]).to eq(0)
+      end
+    end
+  end
+
+  describe '#purge_all when BQ fails' do
+    before do
+      allow(mock_bigquery).to receive(:dataset).and_raise(StandardError, 'BQ unavailable')
+    end
+
+    it 'returns failure without raising' do
+      results = described_class.new.purge_all
+
+      results.each_value do |result|
+        expect(result[:success]).to be false
+        expect(result[:error]).to include('BQ unavailable')
+      end
+    end
+  end
+
+  describe '#preview_all' do
+    let(:count_result) do
+      [{ cnt: 15 }]
+    end
+
+    before do
+      allow(mock_bigquery).to receive(:dataset).and_return(mock_dataset)
+      allow(mock_dataset).to receive(:table).and_return(mock_table)
+      allow(mock_bigquery).to receive(:query).and_return(count_result)
+    end
+
+    it 'returns counts for each table' do
+      counts = described_class.new.preview_all
+
+      counts.each_value do |count|
+        expect(count).to eq(15)
+      end
+    end
+
+    it 'uses SELECT COUNT query' do
+      expect(mock_bigquery).to receive(:query).with(/SELECT COUNT.*WHERE/).at_least(:once).and_return(count_result)
+
+      described_class.new.preview_all
+    end
+  end
+
+  describe 'RETENTION_MONTHS' do
+    it 'is 18 months' do
+      expect(described_class::RETENTION_MONTHS).to eq(18)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- `DataRetentionPurger` service purges BQ rows older than 18 months
- Tables: scan_findings, scan_metadata, scan_costs, penetrator_events
- `rake retention:purge` — run monthly to enforce policy
- `rake retention:dry_run` — preview what would be purged
- Purge events logged as structured JSON for audit evidence
- GCS lifecycle rules documented (configured at infrastructure level)

**Chained from:** PR #251 (scan.rake pipeline)

## Test plan

- [x] 9 RSpec examples, 0 failures
- [x] Full suite: 538 examples, 0 failures

Closes #242

🤖 Generated with [Claude Code](https://claude.com/claude-code)