### PR TITLE
compliance: SOC 2 structured audit logging (#243)

### DIFF
--- a/app/services/audit_logger.rb
+++ b/app/services/audit_logger.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require 'json'
+require 'securerandom'
+
+class AuditLogger
+  ACTIONS = %w[
+    scan_started scan_completed scan_failed
+    json_exported bq_loaded
+    cve_enrichment_completed
+    retention_purge_completed
+  ].freeze
+
+  def initialize
+    @logger = Rails.logger
+  end
+
+  def log(action:, scan_id:, **fields)
+    entry = {
+      event: 'audit',
+      event_id: SecureRandom.uuid,
+      timestamp: Time.now.utc.iso8601,
+      action: action,
+      scan_id: scan_id,
+      actor: actor_identity,
+      schema_version: defined?(ScanResultsExporter) ? ScanResultsExporter::SCHEMA_VERSION : nil
+    }.merge(fields).compact
+
+    @logger.info(entry.to_json)
+    entry
+  end
+
+  def scan_started(scan)
+    log(
+      action: 'scan_started',
+      scan_id: scan.id,
+      target_name: scan.target.name,
+      profile: scan.profile
+    )
+  end
+
+  def scan_completed(scan, gcs_path: nil)
+    log(
+      action: 'scan_completed',
+      scan_id: scan.id,
+      target_name: scan.target.name,
+      profile: scan.profile,
+      finding_count: scan.findings.non_duplicate.count,
+      duration_seconds: scan.duration&.to_i,
+      status: scan.status,
+      gcs_output_path: gcs_path
+    )
+  end
+
+  def scan_failed(scan, error:)
+    log(
+      action: 'scan_failed',
+      scan_id: scan.id,
+      target_name: scan.target.name,
+      profile: scan.profile,
+      duration_seconds: scan.duration&.to_i,
+      status: 'failed',
+      error: error.to_s.truncate(500)
+    )
+  end
+
+  def json_exported(scan, gcs_path:)
+    log(
+      action: 'json_exported',
+      scan_id: scan.id,
+      gcs_output_path: gcs_path,
+      finding_count: scan.findings.non_duplicate.count
+    )
+  end
+
+  def bq_loaded(scan, rows_logged:)
+    log(
+      action: 'bq_loaded',
+      scan_id: scan.id,
+      rows_logged: rows_logged
+    )
+  end
+
+  private
+
+  def actor_identity
+    {
+      vm_name: ENV['VM_NAME'] || ENV['HOSTNAME'] || Socket.gethostname,
+      service_account: ENV['GOOGLE_SERVICE_ACCOUNT'],
+      scan_mode: ENV.fetch('SCAN_MODE', 'dev')
+    }.compact
+  end
+end

--- a/lib/tasks/scan.rake
+++ b/lib/tasks/scan.rake
@@ -21,8 +21,10 @@ namespace :scan do
     scan = target.scans.create!(profile:)
     puts "Scan ID: #{scan.id}"
 
-    # Initialize cost tracker
+    # Initialize cost tracker and audit logger
     cost_logger = ScanCostLogger.new(scan)
+    audit = AuditLogger.new
+    audit.scan_started(scan)
 
     # Execute scan
     orchestrator = ScanOrchestrator.new(scan)
@@ -51,6 +53,7 @@ namespace :scan do
     puts "\n--- Scan Results Export ---"
     gcs_scan_results_path = ScanResultsExporter.new(scan).export
     puts "  Exported v#{ScanResultsExporter::SCHEMA_VERSION} to #{gcs_scan_results_path}"
+    audit.json_exported(scan, gcs_path: gcs_scan_results_path)
 
     # Load findings to BigQuery FROM the versioned JSON
     if BigQueryLogger.enabled?
@@ -58,6 +61,7 @@ namespace :scan do
       scan_results = ScanResultsExporter.new(scan).build_envelope
       logged = BigQueryLogger.new.log_from_json(scan_results)
       puts "  Logged #{logged} findings to BigQuery (#{ENV.fetch('SCAN_MODE', 'dev')})"
+      audit.bq_loaded(scan, rows_logged: logged)
     end
 
     # Generate reports — kept during transition, will move to reporter
@@ -93,6 +97,9 @@ namespace :scan do
     # Send notifications
     puts "\n--- Notifications ---"
     NotificationService.new(scan).notify
+
+    # Audit: scan completed
+    audit.scan_completed(scan, gcs_path: gcs_scan_results_path)
 
     # Summary
     scan.reload

--- a/spec/services/audit_logger_spec.rb
+++ b/spec/services/audit_logger_spec.rb
@@ -1,0 +1,144 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe AuditLogger do
+  subject(:audit) { described_class.new }
+
+  let(:target) { create(:target, name: 'Test App') }
+  let(:scan) { create(:scan, :completed, target:) }
+
+  before do
+    allow(Rails.logger).to receive(:info)
+    create(:finding, scan:, duplicate: false, fingerprint: SecureRandom.hex(32))
+  end
+
+  describe '#log' do
+    it 'outputs structured JSON to logger' do
+      audit.log(action: 'test_action', scan_id: 'scan-123', extra: 'value')
+
+      expect(Rails.logger).to have_received(:info) do |msg|
+        parsed = JSON.parse(msg)
+        expect(parsed['event']).to eq('audit')
+        expect(parsed['action']).to eq('test_action')
+        expect(parsed['scan_id']).to eq('scan-123')
+        expect(parsed['extra']).to eq('value')
+      end
+    end
+
+    it 'includes event_id and timestamp' do
+      audit.log(action: 'test', scan_id: 'x')
+
+      expect(Rails.logger).to have_received(:info) do |msg|
+        parsed = JSON.parse(msg)
+        expect(parsed['event_id']).to match(/\A[0-9a-f-]{36}\z/)
+        expect(parsed['timestamp']).to match(/\A\d{4}-\d{2}-\d{2}T/)
+      end
+    end
+
+    it 'includes actor identity' do
+      audit.log(action: 'test', scan_id: 'x')
+
+      expect(Rails.logger).to have_received(:info) do |msg|
+        parsed = JSON.parse(msg)
+        expect(parsed['actor']).to be_a(Hash)
+        expect(parsed['actor']['scan_mode']).to eq('dev')
+      end
+    end
+
+    it 'includes schema_version' do
+      audit.log(action: 'test', scan_id: 'x')
+
+      expect(Rails.logger).to have_received(:info) do |msg|
+        parsed = JSON.parse(msg)
+        expect(parsed['schema_version']).to eq('1.0')
+      end
+    end
+  end
+
+  describe '#scan_started' do
+    it 'logs scan_started with target and profile' do
+      audit.scan_started(scan)
+
+      expect(Rails.logger).to have_received(:info) do |msg|
+        parsed = JSON.parse(msg)
+        expect(parsed['action']).to eq('scan_started')
+        expect(parsed['target_name']).to eq('Test App')
+        expect(parsed['profile']).to eq('standard')
+      end
+    end
+  end
+
+  describe '#scan_completed' do
+    it 'logs scan_completed with finding count and GCS path' do
+      audit.scan_completed(scan, gcs_path: 'scan-results/t/s/scan_results.json')
+
+      expect(Rails.logger).to have_received(:info) do |msg|
+        parsed = JSON.parse(msg)
+        expect(parsed['action']).to eq('scan_completed')
+        expect(parsed['finding_count']).to eq(1)
+        expect(parsed['gcs_output_path']).to eq('scan-results/t/s/scan_results.json')
+        expect(parsed['duration_seconds']).to be_a(Integer)
+      end
+    end
+  end
+
+  describe '#scan_failed' do
+    it 'logs scan_failed with error' do
+      audit.scan_failed(scan, error: 'Connection timeout')
+
+      expect(Rails.logger).to have_received(:info) do |msg|
+        parsed = JSON.parse(msg)
+        expect(parsed['action']).to eq('scan_failed')
+        expect(parsed['error']).to eq('Connection timeout')
+        expect(parsed['status']).to eq('failed')
+      end
+    end
+
+    it 'truncates long error messages' do
+      audit.scan_failed(scan, error: 'x' * 1000)
+
+      expect(Rails.logger).to have_received(:info) do |msg|
+        parsed = JSON.parse(msg)
+        expect(parsed['error'].length).to be <= 500
+      end
+    end
+  end
+
+  describe '#json_exported' do
+    it 'logs json_exported with GCS path and finding count' do
+      audit.json_exported(scan, gcs_path: 'scan-results/path.json')
+
+      expect(Rails.logger).to have_received(:info) do |msg|
+        parsed = JSON.parse(msg)
+        expect(parsed['action']).to eq('json_exported')
+        expect(parsed['gcs_output_path']).to eq('scan-results/path.json')
+        expect(parsed['finding_count']).to eq(1)
+      end
+    end
+  end
+
+  describe '#bq_loaded' do
+    it 'logs bq_loaded with row count' do
+      audit.bq_loaded(scan, rows_logged: 42)
+
+      expect(Rails.logger).to have_received(:info) do |msg|
+        parsed = JSON.parse(msg)
+        expect(parsed['action']).to eq('bq_loaded')
+        expect(parsed['rows_logged']).to eq(42)
+      end
+    end
+  end
+
+  describe 'no sensitive data' do
+    it 'does not include credentials or finding content' do
+      audit.scan_completed(scan)
+
+      expect(Rails.logger).to have_received(:info) do |msg|
+        expect(msg).not_to include('ANTHROPIC_API_KEY')
+        expect(msg).not_to include('evidence')
+        expect(msg).not_to include('ai_assessment')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- `AuditLogger` service emits structured JSON audit events to stdout
- Events: scan_started, scan_completed, scan_failed, json_exported, bq_loaded
- Each entry includes: event_id (UUID), timestamp, actor identity, schema_version
- GCS artifact paths logged for chain of custody
- No credentials, secrets, or finding content in logs
- Integrated into scan.rake pipeline

**Chained from:** PR #252 (data retention)

## Test plan

- [x] 11 RSpec examples, 0 failures
- [x] Full suite: 549 examples, 0 failures

Closes #243

🤖 Generated with [Claude Code](https://claude.com/claude-code)