### PR TITLE
docs: Audit-grade architecture documentation (#244)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,54 @@
+DOCS_DIR = docs
+PDF_DIR = docs/pdf
+DOCS = architecture data_flow data_retention_policy audit_logging separation_of_duties schema_versioning
+
+.PHONY: docs docs-html docs-pdf clean-docs
+
+docs: docs-html docs-pdf
+
+docs-html: $(DOCS:%=$(PDF_DIR)/%.html)
+
+docs-pdf: $(DOCS:%=$(PDF_DIR)/%.pdf)
+
+$(PDF_DIR):
+	mkdir -p $(PDF_DIR)
+
+# Render Mermaid diagrams, then convert to HTML
+$(PDF_DIR)/%.html: $(DOCS_DIR)/%.md | $(PDF_DIR)
+	@echo "Generating HTML: $@"
+	@if command -v mmdc > /dev/null 2>&1; then \
+		mmdc -i $< -o /tmp/mermaid_$*.md -e svg 2>/dev/null || cp $< /tmp/mermaid_$*.md; \
+	else \
+		cp $< /tmp/mermaid_$*.md; \
+	fi
+	pandoc /tmp/mermaid_$*.md -o $@ \
+		--standalone \
+		--metadata title="$*" \
+		--css=https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400&display=swap \
+		-V mainfont="Inter" \
+		-V monofont="JetBrains Mono" \
+		--highlight-style=tango
+	@rm -f /tmp/mermaid_$*.md
+
+# Render Mermaid diagrams, then convert to PDF via xelatex
+$(PDF_DIR)/%.pdf: $(DOCS_DIR)/%.md | $(PDF_DIR)
+	@echo "Generating PDF: $@"
+	@if command -v mmdc > /dev/null 2>&1; then \
+		mmdc -i $< -o /tmp/mermaid_$*.md -e png 2>/dev/null || cp $< /tmp/mermaid_$*.md; \
+	else \
+		cp $< /tmp/mermaid_$*.md; \
+	fi
+	pandoc /tmp/mermaid_$*.md -o $@ \
+		--pdf-engine=xelatex \
+		-V geometry:margin=1in \
+		-V mainfont="Inter" \
+		-V monofont="JetBrains Mono" \
+		-V fontsize=11pt \
+		-V colorlinks=true \
+		-V linkcolor=NavyBlue \
+		-V urlcolor=NavyBlue \
+		--highlight-style=tango
+	@rm -f /tmp/mermaid_$*.md
+
+clean-docs:
+	rm -rf $(PDF_DIR)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,208 @@
+# System Architecture
+
+| | |
+|---|---|
+| **Document** | Peregrine Penetrator Scanner — System Architecture |
+| **Classification** | CONFIDENTIAL |
+| **Version** | 1.0 |
+| **Date** | 2026-03-22 |
+| **Author** | Peregrine Technology Systems |
+
+## Version History
+
+| Version | Date | Author | Changes |
+|---------|------|--------|---------|
+| 1.0 | 2026-03-22 | Peregrine Technology Systems | Initial architecture document |
+
+---
+
+## Overview
+
+The Peregrine Penetration Testing Platform is a three-service architecture that automates web application security assessments. Each service has a single, clearly defined responsibility.
+
+```mermaid
+graph TB
+    subgraph Backend ["Backend (Orchestrator)"]
+        API[API Server]
+        ClientMgmt[Client Management]
+        Auth[Authentication]
+    end
+
+    subgraph Scanner ["Scanner (Ephemeral VM)"]
+        Scanners[Security Scanners]
+        CVE[CVE Enrichment]
+        Exporter[JSON Exporter]
+    end
+
+    subgraph Reporter ["Reporter (Cloud Run)"]
+        AI[AI Analysis]
+        ReportGen[Report Generation]
+    end
+
+    subgraph Storage ["Data Stores"]
+        GCS[Google Cloud Storage]
+        BQ[BigQuery]
+    end
+
+    API -->|Provisions VM| Scanner
+    Scanners --> CVE
+    CVE --> Exporter
+    Exporter -->|Versioned JSON| GCS
+    Exporter -->|Load from JSON| BQ
+    Exporter -->|Callback| API
+    API -->|Triggers| Reporter
+    Reporter -->|Reads JSON| GCS
+    AI --> ReportGen
+    ReportGen -->|Reports| GCS
+    ReportGen -->|Callback| API
+```
+
+## Services
+
+### Scanner (`peregrine-penetrator-scanner`)
+
+**Role:** Execute security scans against a single target URL, enrich findings with CVE intelligence, and output a versioned JSON artifact.
+
+**Deployment:** Ephemeral DigitalOcean VMs, one per URL. Destroyed after scan completes.
+
+**Technology:** Ruby + Sequel ORM + SQLite (ephemeral state)
+
+**Responsibilities:**
+- Run security scanning tools (OWASP ZAP, Nuclei, sqlmap, ffuf, Nikto)
+- Parse and normalize tool output
+- Deduplicate findings via SHA256 fingerprinting
+- Enrich with CVE intelligence (NVD, CISA KEV, EPSS)
+- Export versioned JSON artifact to GCS
+- Load findings into BigQuery from JSON
+- Callback to backend with GCS path
+
+**Does NOT:**
+- Generate reports (moved to Reporter)
+- Run AI analysis (moved to Reporter)
+- Serve HTTP (CLI tool, not web server)
+- Handle multiple URLs (one VM per URL)
+
+### Reporter (`peregrine-penetrator-reporter`)
+
+**Role:** Perform AI-driven security analysis and generate professional penetration test reports.
+
+**Deployment:** Cloud Run (scales to zero, HTTP-triggered)
+
+**Technology:** Ruby + Sinatra
+
+**Responsibilities:**
+- Read scan results JSON from GCS
+- Run AI analysis (multi-provider: Claude, Gemini, Grok)
+- Triage findings with AI assessment
+- Generate executive summary
+- Produce reports: JSON, Markdown, HTML, PDF
+- Upload reports to GCS
+- Callback to backend with report paths
+
+### Backend (`peregrine-penetrator-backend`)
+
+**Role:** API server and orchestrator. Manages clients, authentication, and dispatches scan/report jobs.
+
+**Deployment:** Persistent server (Rails API)
+
+**Technology:** Ruby on Rails
+
+**Responsibilities:**
+- Client and user management
+- Authentication (JWT, OAuth2)
+- Provision scanner VMs (DigitalOcean)
+- Receive scan callbacks, trigger reporter
+- Receive report callbacks, notify clients
+- Webhook event delivery
+- Compliance document generation
+
+## Data Flow
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Backend
+    participant Scanner as Scanner VM
+    participant GCS
+    participant BQ as BigQuery
+    participant Reporter
+
+    Client->>Backend: Request scan
+    Backend->>Scanner: Provision VM (1 URL)
+    Scanner->>Scanner: Run scanners (ZAP, Nuclei, sqlmap, ffuf, Nikto)
+    Scanner->>Scanner: Normalize + deduplicate findings
+    Scanner->>Scanner: CVE enrichment (NVD, KEV, EPSS)
+    Scanner->>GCS: Write versioned JSON (v1.0)
+    Scanner->>BQ: Load findings from JSON
+    Scanner->>Backend: Callback (gcs_scan_results_path)
+    Scanner->>Scanner: VM destroyed
+
+    Backend->>Reporter: POST /generate (GCS path + brand_config)
+    Reporter->>GCS: Read scan results JSON
+    Reporter->>Reporter: AI analysis (triage + executive summary)
+    Reporter->>Reporter: Generate reports (JSON, MD, HTML, PDF)
+    Reporter->>GCS: Upload reports
+    Reporter->>Backend: Callback (report paths)
+    Backend->>Client: Notification (reports ready)
+```
+
+## JSON Contract
+
+The versioned JSON artifact is the contract between Scanner and Reporter.
+
+```mermaid
+graph LR
+    Scanner -->|schema v1.0| GCS
+    GCS -->|schema v1.0| BQ
+    GCS -->|schema v1.0| Reporter
+
+    style GCS fill:#faf5e6,stroke:#c5a55a
+```
+
+**Schema versioning rules:**
+- Every JSON artifact carries a `schema_version` field
+- Every BQ row stamped with the same version
+- Field additions/removals/renames require a version bump
+- Version changes tracked in GitHub issues and release notes
+
+## Security Boundaries
+
+```mermaid
+graph TB
+    subgraph PublicInternet ["Public Internet"]
+        Target[Target Application]
+    end
+
+    subgraph ScannerVM ["Scanner VM (Ephemeral)"]
+        ScanEngine[Scan Engine]
+    end
+
+    subgraph GCP ["Google Cloud Platform"]
+        GCS[Cloud Storage]
+        BQ[BigQuery]
+        CloudRun[Cloud Run]
+        CloudLog[Cloud Logging]
+    end
+
+    subgraph BackendInfra ["Backend Infrastructure"]
+        BackendAPI[API Server]
+    end
+
+    ScanEngine -->|Scans| Target
+    ScanEngine -->|Writes| GCS
+    ScanEngine -->|Loads| BQ
+    ScanEngine -->|Logs| CloudLog
+    CloudRun -->|Reads| GCS
+    CloudRun -->|Writes| GCS
+    CloudRun -->|Logs| CloudLog
+    BackendAPI -->|Triggers| CloudRun
+```
+
+**Key security properties:**
+- Scanner VMs are ephemeral — destroyed after each scan, no persistent state
+- Scanner has no inbound ports — it initiates all connections
+- Reporter runs on Cloud Run with no persistent state
+- All data in transit is encrypted (TLS)
+- All data at rest is encrypted (GCS, BQ default encryption)
+- Audit logs captured via Cloud Logging, sunk to BQ for long-term retention
+- 18-month data retention with automated purge

--- a/docs/audit_logging.md
+++ b/docs/audit_logging.md
@@ -1,0 +1,100 @@
+# Audit Logging
+
+| | |
+|---|---|
+| **Document** | Peregrine Penetrator Scanner — Audit Logging |
+| **Classification** | CONFIDENTIAL |
+| **Version** | 1.0 |
+| **Date** | 2026-03-22 |
+| **Author** | Peregrine Technology Systems |
+
+## Version History
+
+| Version | Date | Author | Changes |
+|---------|------|--------|---------|
+| 1.0 | 2026-03-22 | Peregrine Technology Systems | Initial audit logging specification |
+
+---
+
+## Overview
+
+The scanner emits structured JSON audit events to stdout, captured by Cloud Logging and sunk to BigQuery for long-term retention. Audit logs provide an immutable record of scan lifecycle events for SOC 2 Type II and ISO 27001 compliance.
+
+## Audit Event Schema
+
+```json
+{
+  "event": "audit",
+  "event_id": "UUID",
+  "timestamp": "ISO8601",
+  "action": "scan_started|scan_completed|scan_failed|json_exported|bq_loaded",
+  "scan_id": "UUID",
+  "actor": {
+    "vm_name": "string",
+    "service_account": "string",
+    "scan_mode": "dev|staging|production"
+  },
+  "schema_version": "1.0",
+  "target_name": "string",
+  "profile": "string",
+  "finding_count": 0,
+  "duration_seconds": 0,
+  "status": "string",
+  "gcs_output_path": "string",
+  "rows_logged": 0,
+  "error": "string (max 500 chars)"
+}
+```
+
+## Events
+
+| Action | When | Key Fields |
+|--------|------|------------|
+| `scan_started` | Scan begins | target_name, profile |
+| `scan_completed` | Scan finishes successfully | finding_count, duration_seconds, gcs_output_path |
+| `scan_failed` | Scan errors out | error, duration_seconds |
+| `json_exported` | JSON artifact written to GCS | gcs_output_path, finding_count |
+| `bq_loaded` | Findings loaded into BigQuery | rows_logged |
+| `retention_purge_completed` | Data retention purge ran | results (per-table counts) |
+
+## Chain of Custody
+
+The `gcs_output_path` in audit events establishes chain of custody:
+
+```mermaid
+sequenceDiagram
+    participant Scanner
+    participant AuditLog as Audit Log
+    participant GCS
+    participant BQ
+
+    Scanner->>AuditLog: scan_started (scan_id, target)
+    Scanner->>GCS: Write scan_results.json
+    Scanner->>AuditLog: json_exported (gcs_output_path)
+    Scanner->>BQ: Load from JSON
+    Scanner->>AuditLog: bq_loaded (rows_logged)
+    Scanner->>AuditLog: scan_completed (finding_count, gcs_path)
+```
+
+An auditor can trace: scan X started at time T1, produced artifact at GCS path P, loaded N rows into BQ, completed at time T2.
+
+## What is NOT Logged
+
+- API keys or credentials
+- Raw vulnerability evidence or finding content
+- Authentication tokens
+- Target application responses
+- PII of any kind
+
+## Retention
+
+Audit logs follow the same 18-month retention policy as all scan data. See [Data Retention Policy](data_retention_policy.md).
+
+## Compliance Mapping
+
+| Requirement | Standard | How Met |
+|-------------|----------|---------|
+| Audit trail | SOC 2 CC7.2 | Structured JSON events for all scan lifecycle actions |
+| Access logging | ISO 27001 A.8.15 | Actor identity (VM, service account) in every event |
+| Non-repudiation | SOC 2 CC7.3 | Immutable Cloud Logging → BQ sink |
+| Event correlation | ISO 27001 A.8.15 | event_id (UUID) and scan_id for cross-referencing |

--- a/docs/data_flow.md
+++ b/docs/data_flow.md
@@ -1,0 +1,138 @@
+# Data Flow
+
+| | |
+|---|---|
+| **Document** | Peregrine Penetrator Scanner — Data Flow |
+| **Classification** | CONFIDENTIAL |
+| **Version** | 1.0 |
+| **Date** | 2026-03-22 |
+| **Author** | Peregrine Technology Systems |
+
+## Version History
+
+| Version | Date | Author | Changes |
+|---------|------|--------|---------|
+| 1.0 | 2026-03-22 | Peregrine Technology Systems | Initial data flow document |
+
+---
+
+## JSON-First Pipeline
+
+The scanner produces a single canonical output: a versioned JSON artifact stored in GCS. All downstream consumers (BigQuery, Reporter) read from this artifact.
+
+```mermaid
+flowchart TD
+    A[Scanner Tools] -->|Raw output| B[Result Parsers]
+    B -->|Normalized findings| C[FindingNormalizer]
+    C -->|Deduplicated| D[CVE Enrichment]
+    D -->|Enriched findings| E[ScanResultsExporter]
+    E -->|schema v1.0| F[GCS: scan_results.json]
+    F -->|Load from JSON| G[BigQuery]
+    F -->|Read JSON| H[Reporter Service]
+    H -->|AI Analysis| I[Enriched Data]
+    I -->|Generate| J[Reports: JSON, MD, HTML, PDF]
+    J --> K[GCS: Reports]
+```
+
+## Scan Results JSON Schema (v1.0)
+
+```json
+{
+  "schema_version": "1.0",
+  "metadata": {
+    "scan_id": "UUID",
+    "target_name": "string",
+    "target_urls": ["string"],
+    "profile": "quick|standard|thorough",
+    "started_at": "ISO8601",
+    "completed_at": "ISO8601",
+    "duration_seconds": 1234,
+    "tool_statuses": {},
+    "generated_at": "ISO8601"
+  },
+  "summary": {
+    "total_findings": 12,
+    "by_severity": {"critical": 1, "high": 3, "medium": 5, "low": 2, "info": 1},
+    "tools_run": ["zap", "nuclei", "sqlmap"],
+    "duration_seconds": 1234
+  },
+  "findings": [{
+    "id": "UUID",
+    "source_tool": "zap",
+    "severity": "high",
+    "title": "SQL Injection",
+    "url": "https://target.com/login",
+    "parameter": "username",
+    "cwe_id": "CWE-89",
+    "cve_id": "CVE-2024-1234",
+    "cvss_score": 9.8,
+    "epss_score": 0.95,
+    "kev_known_exploited": true,
+    "evidence": {}
+  }]
+}
+```
+
+## BigQuery Tables
+
+### `scan_findings_{mode}`
+
+One row per non-duplicate finding, loaded from the JSON artifact.
+
+| Column | Type | Source |
+|--------|------|--------|
+| fingerprint | STRING | finding.id |
+| site | STRING | metadata.target_urls[0] |
+| scan_id | STRING | metadata.scan_id |
+| scan_date | TIMESTAMP | metadata.started_at |
+| profile | STRING | metadata.profile |
+| schema_version | STRING | schema_version |
+| severity | STRING | finding.severity |
+| title | STRING | finding.title |
+| tool | STRING | finding.source_tool |
+| cwe_id | STRING | finding.cwe_id |
+| cve_id | STRING | finding.cve_id |
+| url | STRING | finding.url |
+| parameter | STRING | finding.parameter |
+| cvss_score | FLOAT | finding.cvss_score |
+| epss_score | FLOAT | finding.epss_score |
+| kev_known_exploited | BOOLEAN | finding.kev_known_exploited |
+| evidence | STRING (JSON) | finding.evidence |
+
+### `scan_metadata_{mode}`
+
+One row per scan.
+
+| Column | Type | Source |
+|--------|------|--------|
+| scan_id | STRING | metadata.scan_id |
+| target_name | STRING | metadata.target_name |
+| profile | STRING | metadata.profile |
+| duration_seconds | INTEGER | summary.duration_seconds |
+| tool_statuses | STRING (JSON) | metadata.tool_statuses |
+| schema_version | STRING | schema_version |
+| scan_date | TIMESTAMP | metadata.started_at |
+| total_findings | INTEGER | summary.total_findings |
+| by_severity | STRING (JSON) | summary.by_severity |
+
+## GCS Storage Paths
+
+| Artifact | Path | Retention |
+|----------|------|-----------|
+| Scan results JSON | `scan-results/{target_id}/{scan_id}/scan_results.json` | 18 months |
+| JSON report | `reports/{target_id}/{scan_id}/scan_{id}_report.json` | 18 months |
+| Markdown report | `reports/{target_id}/{scan_id}/scan_{id}_report.md` | 18 months |
+| HTML report | `reports/{target_id}/{scan_id}/scan_{id}_report.html` | 18 months |
+| PDF report | `reports/{target_id}/{scan_id}/scan_{id}_report.pdf` | 18 months |
+
+## Audit Log Flow
+
+```mermaid
+flowchart LR
+    Scanner -->|Structured JSON| A[stdout]
+    Reporter -->|Structured JSON| B[stdout]
+    A --> C[Cloud Logging]
+    B --> C
+    C -->|Sink| D[BigQuery: audit_logs]
+    D -->|18-month retention| E[Automated Purge]
+```

--- a/docs/data_retention_policy.md
+++ b/docs/data_retention_policy.md
@@ -1,0 +1,116 @@
+# Data Retention Policy
+
+| | |
+|---|---|
+| **Document** | Peregrine Penetrator — Data Retention Policy |
+| **Classification** | CONFIDENTIAL |
+| **Version** | 1.0 |
+| **Date** | 2026-03-22 |
+| **Author** | Peregrine Technology Systems |
+| **Review Frequency** | Annual |
+
+## Version History
+
+| Version | Date | Author | Changes |
+|---------|------|--------|---------|
+| 1.0 | 2026-03-22 | Peregrine Technology Systems | Initial retention policy |
+
+---
+
+## Policy Statement
+
+All scan data, reports, and audit logs are retained for **18 months** from the date of creation. Data older than 18 months is automatically destroyed on a rolling basis. Destruction events are logged for audit evidence.
+
+## Retention Period
+
+| Data Type | Location | Retention | Destruction Method |
+|-----------|----------|-----------|-------------------|
+| Scan results JSON | GCS | 18 months | GCS lifecycle rule |
+| Generated reports (PDF, HTML, etc.) | GCS | 18 months | GCS lifecycle rule |
+| Finding rows | BigQuery | 18 months | Scheduled DELETE query |
+| Scan metadata rows | BigQuery | 18 months | Scheduled DELETE query |
+| Scan cost rows | BigQuery | 18 months | Scheduled DELETE query |
+| Audit log rows | BigQuery | 18 months | Scheduled DELETE query |
+
+## Lifecycle
+
+```mermaid
+flowchart TD
+    A[Scan Executed] -->|Day 0| B[Data Created]
+    B --> C[GCS: JSON + Reports]
+    B --> D[BQ: Findings + Metadata]
+    B --> E[BQ: Audit Logs]
+
+    C -->|18 months| F[GCS Lifecycle Rule]
+    D -->|18 months| G[BQ Scheduled Query]
+    E -->|18 months| H[BQ Scheduled Query]
+
+    F --> I[Objects Deleted]
+    G --> J[Rows Deleted]
+    H --> K[Rows Deleted]
+
+    I --> L[Deletion Logged]
+    J --> L
+    K --> L
+    L -->|Audit evidence| M[Cloud Logging]
+```
+
+## Enforcement
+
+### GCS Lifecycle Rules
+
+Applied at the bucket level to automatically delete objects older than 18 months:
+
+```json
+{
+  "lifecycle": {
+    "rule": [{
+      "action": { "type": "Delete" },
+      "condition": { "age": 548 }
+    }]
+  }
+}
+```
+
+### BigQuery Scheduled Queries
+
+Run monthly via `rake retention:purge`:
+
+```sql
+DELETE FROM `pentest_history.scan_findings_{mode}`
+WHERE scan_date < TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 548 DAY);
+
+DELETE FROM `pentest_history.scan_metadata_{mode}`
+WHERE scan_date < TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 548 DAY);
+
+DELETE FROM `audit_logs.penetrator_events`
+WHERE timestamp < TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 548 DAY);
+```
+
+### Dry Run
+
+Preview what would be purged before executing:
+
+```bash
+rake retention:dry_run
+```
+
+## Destruction Evidence
+
+Every purge operation logs:
+- Timestamp of purge execution
+- Tables affected
+- Row counts deleted per table
+- Cutoff date used
+- Success/failure status
+
+These logs are themselves subject to the 18-month retention policy.
+
+## Compliance Mapping
+
+| Requirement | Standard | How Met |
+|-------------|----------|---------|
+| Data retention policy | SOC 2 CC6.5 | This document + automated enforcement |
+| Data destruction | SOC 2 CC6.5 | GCS lifecycle + BQ scheduled queries |
+| Destruction evidence | ISO 27001 A.8.10 | Purge events logged to Cloud Logging |
+| Policy review | ISO 27001 A.5.1 | Annual review (documented in version history) |

--- a/docs/schema_versioning.md
+++ b/docs/schema_versioning.md
@@ -1,0 +1,72 @@
+# Schema Versioning
+
+| | |
+|---|---|
+| **Document** | Peregrine Penetrator — JSON Schema Versioning |
+| **Classification** | CONFIDENTIAL |
+| **Version** | 1.0 |
+| **Date** | 2026-03-22 |
+| **Author** | Peregrine Technology Systems |
+
+## Version History
+
+| Version | Date | Author | Changes |
+|---------|------|--------|---------|
+| 1.0 | 2026-03-22 | Peregrine Technology Systems | Initial schema versioning specification |
+
+---
+
+## Overview
+
+The scan results JSON schema is the contract between the Scanner and the Reporter. Every JSON artifact and every BigQuery row carries a `schema_version` field to ensure data provenance and compatibility.
+
+## Versioning Rules
+
+1. The `schema_version` field is **required** in every JSON artifact
+2. Every BigQuery row is stamped with the `schema_version` of the JSON it was loaded from
+3. The Reporter **validates** the schema version before processing and rejects unknown versions
+4. Version follows `MAJOR.MINOR` format
+
+## What Triggers a Version Bump
+
+| Change Type | Version Bump | Example |
+|-------------|-------------|---------|
+| New optional field added | Minor (1.0 → 1.1) | Add `target_url` (singular) |
+| Required field added | Major (1.x → 2.0) | New required metadata field |
+| Field removed | Major (1.x → 2.0) | Remove `ai_assessment` from findings |
+| Field renamed | Major (1.x → 2.0) | Rename `target_urls` → `target_url` |
+| Field type changed | Major (1.x → 2.0) | Change `cvss_score` from float to string |
+| No schema change | No bump | Code-only changes |
+
+## Change Process
+
+```mermaid
+flowchart TD
+    A[Schema change needed] --> B[Create GitHub issue]
+    B --> C[Document change in issue]
+    C --> D[Update scanner code]
+    D --> E[Update reporter validator]
+    E --> F[Update BQ schema if needed]
+    F --> G[Bump schema_version constant]
+    G --> H[Update RELEASE_NOTES]
+    H --> I[Tag release]
+```
+
+1. **Create a GitHub issue** describing the schema change and rationale
+2. **Update the scanner** — modify `ScanResultsExporter` and bump `SCHEMA_VERSION`
+3. **Update the reporter** — add support for the new version in the schema validator
+4. **Update BigQuery** — add/modify columns if needed
+5. **Document** — update RELEASE_NOTES and schema documentation
+6. **Tag release** — version tag on both scanner and reporter repos
+
+## Version History
+
+| Version | Date | Changes | Issue |
+|---------|------|---------|-------|
+| 1.0 | 2026-03-22 | Initial schema | #238 |
+
+## Compatibility
+
+- The Reporter should support the **current version and one prior version**
+- BigQuery rows from older versions remain queryable (old rows keep their schema_version)
+- GCS artifacts are immutable — an artifact written with v1.0 stays v1.0 forever

--- a/docs/separation_of_duties.md
+++ b/docs/separation_of_duties.md
@@ -1,0 +1,76 @@
+# Separation of Duties
+
+| | |
+|---|---|
+| **Document** | Peregrine Penetrator — Separation of Duties |
+| **Classification** | CONFIDENTIAL |
+| **Version** | 1.0 |
+| **Date** | 2026-03-22 |
+| **Author** | Peregrine Technology Systems |
+
+## Version History
+
+| Version | Date | Author | Changes |
+|---------|------|--------|---------|
+| 1.0 | 2026-03-22 | Peregrine Technology Systems | Initial separation of duties document |
+
+---
+
+## Service Responsibilities
+
+```mermaid
+graph TB
+    subgraph Scanner ["Scanner (Ephemeral VM)"]
+        S1[Scan target URL]
+        S2[Parse tool output]
+        S3[Deduplicate findings]
+        S4[CVE enrichment]
+        S5[Export JSON to GCS]
+        S6[Load BQ from JSON]
+    end
+
+    subgraph Reporter ["Reporter (Cloud Run)"]
+        R1[AI finding triage]
+        R2[Executive summary]
+        R3[Report generation]
+        R4[Upload reports to GCS]
+    end
+
+    subgraph Backend ["Backend (API Server)"]
+        B1[Client management]
+        B2[Authentication]
+        B3[VM provisioning]
+        B4[Trigger reporter]
+        B5[Deliver reports to clients]
+    end
+
+    S5 --> R1
+    S6 -.->|Analytics| B5
+    R4 --> B5
+    B3 --> S1
+    B4 --> R1
+```
+
+## Access Boundaries
+
+| Service | GCS Access | BQ Access | External APIs | Target Access |
+|---------|-----------|-----------|---------------|---------------|
+| Scanner | Write (scan results) | Write (findings, metadata) | NVD, CISA KEV | Scan target URLs |
+| Reporter | Read (scan results), Write (reports) | Write (audit logs) | Claude, Gemini, Grok APIs | None |
+| Backend | Read (reports, signed URLs) | Read (dashboards) | DigitalOcean, Slack, Email | None |
+
+## Why This Separation Matters
+
+1. **Scanner cannot generate reports** — it produces factual data only. Interpretation is the Reporter's job.
+2. **Reporter cannot scan** — it has no access to target applications or scanning tools.
+3. **Backend cannot modify scan data** — it orchestrates but does not touch findings or results.
+4. **Each service has minimum necessary permissions** — principle of least privilege.
+5. **Scanner VMs are ephemeral** — no persistent state, no long-lived credentials, destroyed after use.
+
+## Compliance Mapping
+
+| Requirement | Standard | How Met |
+|-------------|----------|---------|
+| Separation of duties | SOC 2 CC6.1 | Three services with non-overlapping responsibilities |
+| Least privilege | ISO 27001 A.8.3 | Per-service IAM roles and access scopes |
+| Change management | SOC 2 CC8.1 | Each service in its own repo with independent CI/CD |


### PR DESCRIPTION
## Summary

Six professional audit-grade documents with Mermaid diagrams:
- **architecture.md** — three-service system architecture (Scanner, Reporter, Backend)
- **data_flow.md** — JSON-first pipeline, BQ schema, GCS paths
- **data_retention_policy.md** — 18-month rolling retention with compliance mapping
- **audit_logging.md** — structured event schema, chain of custody
- **separation_of_duties.md** — service boundaries, access control matrix
- **schema_versioning.md** — JSON contract versioning rules and change process

Makefile added: `make docs` generates HTML + PDF via pandoc/xelatex with Mermaid diagrams.

All docs include version history, classification headers, and SOC 2 / ISO 27001 compliance mapping tables.

**Chained from:** PR #253 (audit logging)

## Test plan

- [x] Full suite: 549 examples, 0 failures
- [ ] `make docs` generates HTML + PDF (requires pandoc + xelatex)

Closes #244

🤖 Generated with [Claude Code](https://claude.com/claude-code)