### PR TITLE
chore: Prepare repo rename to peregrine-penetrator-scanner (#247)

### DIFF
--- a/.buildkite/scripts/promote.sh
+++ b/.buildkite/scripts/promote.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 BASE="$1"
 HEAD="$2"
 MODE="${3:-manual}"
-REPO="Peregrine-Technology-Systems/peregrine-penetrator"
+REPO="Peregrine-Technology-Systems/peregrine-penetrator-scanner"
 API="https://api.github.com"
 
 if [ -z "${GH_TOKEN:-}" ]; then

--- a/.buildkite/scripts/trigger-scan.sh
+++ b/.buildkite/scripts/trigger-scan.sh
@@ -30,10 +30,10 @@ esac
 
 # Fetch secrets for scan notifications
 SLACK_WEBHOOK_URL=$(gcloud secrets versions access latest \
-  --secret="peregrine-penetrator--slack-webhook-url" \
+  --secret="peregrine-penetrator-scanner--slack-webhook-url" \
   --project=ci-runners-de 2>/dev/null || echo "")
 NOTIFICATION_EMAIL=$(gcloud secrets versions access latest \
-  --secret="peregrine-penetrator--notification-email" \
+  --secret="peregrine-penetrator-scanner--notification-email" \
   --project=ci-runners-de 2>/dev/null || echo "")
 
 echo "Launching ${ENV} scan VM: ${VM_NAME}"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,7 @@ NotificationService (Slack webhook + email)
 
 ## CI/CD
 
-CI runs on Buildkite (not GitHub Actions). Pipeline config: `.buildkite/pipeline.yml`. Pipeline slug: `peregrine-penetrator`, org: `chaudhuri-and-co`. Secrets are in GCP Secret Manager in the `ci-runners-de` project, following the `{pipeline-slug}--{secret-name}` naming convention.
+CI runs on Buildkite (not GitHub Actions). Pipeline config: `.buildkite/pipeline.yml`. Pipeline slug: `peregrine-penetrator-scanner`, org: `chaudhuri-and-co`. Secrets are in GCP Secret Manager in the `ci-runners-de` project, following the `{pipeline-slug}--{secret-name}` naming convention.
 
 ## Security & Ethics
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -26,7 +26,7 @@ These are bundled in the Docker image but can be installed locally for developme
 ```bash
 # Clone the repository
 git clone <repo-url>
-cd peregrine-penetrator
+cd peregrine-penetrator-scanner
 
 # Install dependencies
 bundle install
@@ -298,7 +298,7 @@ gh pr create --base develop --title "feat: describe the change"
 ## Project Structure
 
 ```
-peregrine-penetrator/
+peregrine-penetrator-scanner/
   app/
     controllers/          # Thin controllers (10-15 lines max)
     models/               # Domain models with UUID PKs

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Peregrine Penetrator
 
 <!-- Badges -->
-[![Build status](https://badge.buildkite.com/3e8ca31d1b42f054f917dd33f13863ef90099294aa2b703484.svg)](https://buildkite.com/chaudhuri-and-co/peregrine-penetrator)
+[![Build status](https://badge.buildkite.com/3e8ca31d1b42f054f917dd33f13863ef90099294aa2b703484.svg)](https://buildkite.com/chaudhuri-and-co/peregrine-penetrator-scanner)
 ![Ruby](https://img.shields.io/badge/ruby-3.2.2-CC342D?logo=ruby&logoColor=white)
 ![Rails](https://img.shields.io/badge/rails-7.1-CC0000?logo=rubyonrails&logoColor=white)
 ![Coverage](https://img.shields.io/badge/coverage-95.85%25-brightgreen)
@@ -68,8 +68,8 @@ Cloud Scheduler (*/10) → vm-scavenger → SSH liveness check → delete orphan
 
 ### Local Development
 ```bash
-git clone https://github.com/Peregrine-Technology-Systems/peregrine-penetrator.git
-cd peregrine-penetrator
+git clone https://github.com/Peregrine-Technology-Systems/peregrine-penetrator-scanner.git
+cd peregrine-penetrator-scanner
 bundle install
 rails db:create db:migrate
 bundle exec rspec

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -15,7 +15,7 @@
 - Pass SCAN_MODE env var to Docker in scan VMs so BigQuery logs to correct table (#134)
 - Orphan VM scavenger: auto-delete scan VMs older than 30 minutes (#146)
 - Scan VMs now pull environment-tagged Docker images (`:staging`/`:production`) instead of `:latest` (#148)
-- Repo renamed from `web-app-penetration-test` to `peregrine-penetrator` (#150)
+- Repo renamed from `web-app-penetration-test` to `peregrine-penetrator-scanner` (#150)
 - Report TOC: all major sections (Findings Summary, Detailed Findings, Test Methodology, Appendix) now at Level 1 (#154)
 - Auto-assign repo owner as reviewer on staging→main promotion PRs (#161)
 

--- a/spec/cloud/promote_script_spec.rb
+++ b/spec/cloud/promote_script_spec.rb
@@ -19,6 +19,6 @@ RSpec.describe 'promote.sh' do # rubocop:disable RSpec/DescribeClass
   end
 
   it 'uses the correct repo path' do
-    expect(script).to include('Peregrine-Technology-Systems/peregrine-penetrator')
+    expect(script).to include('Peregrine-Technology-Systems/peregrine-penetrator-scanner')
   end
 end


### PR DESCRIPTION
## Summary

Updates all in-repo references from `peregrine-penetrator` to `peregrine-penetrator-scanner`:
- CLAUDE.md, README.md, DEVELOPMENT.md, RELEASE_NOTES.md
- Buildkite promote.sh and trigger-scan.sh scripts
- GCP Secret Manager references (pipeline slug)
- Promote script spec

After this PR merges, run: `gh repo rename peregrine-penetrator-scanner`
Then update local remote: `git remote set-url origin git@github.com:Peregrine-Technology-Systems/peregrine-penetrator-scanner.git`
And rename local folder: `mv peregrine-penetrator peregrine-penetrator-scanner`

**Chained from:** PR #254 (architecture docs)

## Test plan

- [x] Full suite: 549 examples, 0 failures
- [ ] Verify Buildkite pipeline after rename

Closes #247

🤖 Generated with [Claude Code](https://claude.com/claude-code)