### PR TITLE
docs: update README, RELEASE_NOTES, CLAUDE.md for v0.3.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,26 +2,29 @@
 
 ## Project Overview
 
-Automated web application penetration testing platform built with Ruby on Rails. Orchestrates multiple open-source security scanning tools (OWASP ZAP, Nuclei, sqlmap, ffuf, Nikto) against target URLs, aggregates and deduplicates findings, enriches with CVE intelligence, applies AI analysis via Claude API, and generates professional reports.
+Security scanning engine built with Ruby + Sequel ORM. Orchestrates open-source penetration testing tools (OWASP ZAP, Nuclei, sqlmap, ffuf, Nikto) against target URLs, normalizes and deduplicates findings, enriches with CVE intelligence, and exports structured JSON results to GCS and BigQuery.
+
+Report generation, AI analysis, ticketing, and email notifications have been extracted to the [reporter](https://github.com/Peregrine-Technology-Systems/peregrine-penetrator-reporter) and backend services.
 
 ## Build & Run Commands
 
 - Install deps: `bundle install`
-- Create DB: `rails db:create db:migrate`
 - Run tests: `bundle exec rspec`
 - Run single test: `bundle exec rspec spec/models/target_spec.rb`
 - Lint: `bundle exec rubocop`
 - Auto-fix lint: `bundle exec rubocop -A`
 - List scan profiles: `bundle exec rake scan:profiles`
 - Validate profiles: `bundle exec rake scan:validate_profiles`
-- Run scan: `SCAN_PROFILE=standard TARGET_URLS='["https://example.com"]' bundle exec rake scan:run`
-- Docker build: `docker build -f docker/Dockerfile -t pentest-platform .`
-- Docker compose (with DVWA): `docker-compose -f docker/docker-compose.yml up`
+- Run scan: `bin/scan --profile standard --name "My App" --urls '["https://example.com"]'`
+- Run scan (env vars): `SCAN_PROFILE=standard TARGET_NAME="My App" TARGET_URLS='["https://example.com"]' bin/scan`
+- Docker build: `docker build -f docker/Dockerfile -t scanner .`
 
 ## Architecture
 
 ```
-ScanOrchestrator (central coordinator)
+bin/scan (CLI entry point)
+  ↓
+ScanOrchestrator
 ├── Phase 1 Discovery: FfufScanner + NiktoScanner (parallel)
 ├── Phase 2 Active: ZapScanner (full DAST scan)
 └── Phase 3 Targeted: NucleiScanner + SqlmapScanner (parallel)
@@ -30,33 +33,51 @@ FindingNormalizer (SHA256 fingerprint dedup)
      ↓
 CveIntelligenceService (NVD, CISA KEV, EPSS, OSV enrichment)
      ↓
-AiAnalyzer (Claude API triage + executive summary)
+ScanResultsExporter (v1.0 JSON envelope → GCS)
      ↓
-ReportGenerator (JSON, Markdown, HTML, PDF via pandoc/xelatex) → StorageService (GCS/local)
+BigQueryLogger (findings + metadata + costs)
      ↓
-NotificationService (Slack webhook + email)
+ScanCallbackService (POST to backend API)
+     ↓
+SlackNotifier (webhook)
 ```
 
 ### Key Directories
-- `app/models/` — Target, Scan, Finding, Report (UUID PKs), ScanProfile (value object)
-- `app/services/` — Core services: ScanOrchestrator, FindingNormalizer, ReportGenerator, etc.
+- `lib/penetrator.rb` — Boot module (replaces Rails): `.root`, `.logger`, `.env`, `.db`, `.boot!`
+- `lib/models/` — Sequel models: Target, Scan, Finding (UUID PKs)
+- `app/models/` — Value objects: ScanProfile
+- `app/services/` — Core services: ScanOrchestrator, FindingNormalizer, ScanResultsExporter, etc.
 - `app/services/scanners/` — Tool-specific scanner classes extending ScannerBase
 - `app/services/result_parsers/` — Normalize each tool's output format
-- `app/views/reports/` — HTML report template (ERB)
+- `app/services/cve_clients/` — NVD, CISA KEV, EPSS, OSV API clients
 - `config/scan_profiles/` — YAML scan configs (quick, standard, thorough)
+- `bin/scan` — CLI entry point (supports ENV vars and flags)
+- `db/sequel_migrations/` — Sequel migrations (targets, scans, findings)
 - `docker/` — Dockerfile and docker-compose files
 - `infra/` — Pulumi Ruby IaC for GCP
-- `lib/tasks/scan.rake` — Rake tasks for running scans
 
-### Data Models (all UUID primary keys)
+### Data Models (all UUID primary keys, Sequel ORM)
 - **Target** — name, urls (JSON), auth_type, scope_config, brand_config
-- **Scan** — belongs_to Target, profile, status, tool_statuses (JSON), summary (JSON)
-- **Finding** — belongs_to Scan, source_tool, severity, title, url, cwe_id, fingerprint, evidence (JSON)
-- **Report** — belongs_to Scan, format (json/html/pdf), gcs_path, status
+- **Scan** — many_to_one Target, one_to_many Findings, profile, status, tool_statuses (JSON), summary (JSON)
+- **Finding** — many_to_one Scan, source_tool, severity, title, url, cwe_id, fingerprint, evidence (JSON)
+
+### Sequel Notes
+- JSON columns use `plugin :serialization, :json, :column_name`
+- In-place hash mutations are NOT detected — always use `model.col = hash.merge(new_keys)` then `save_changes`
+- Use `findings_dataset` (not `findings`) when chaining queries — `findings` returns a cached Array
+- Dataset methods: `.count` (not `.size`), `.exclude` (not `.where.not`), `.find_or_create`
 
 ## CI/CD
 
-CI runs on Buildkite (not GitHub Actions). Pipeline config: `.buildkite/pipeline.yml`. Pipeline slug: `peregrine-penetrator-scanner`, org: `chaudhuri-and-co`. Secrets are in GCP Secret Manager in the `ci-runners-de` project, following the `{pipeline-slug}--{secret-name}` naming convention.
+CI runs on Woodpecker CI (self-hosted at d3ci42.peregrinetechsys.net). Pipeline configs in `.woodpecker/`. Secrets are Woodpecker repo-level secrets.
+
+| Pipeline | Trigger | Steps |
+|----------|---------|-------|
+| `ci.yaml` | Push (all branches except main) | RSpec + RuboCop (parallel) |
+| `build.yaml` | Push to development (Gemfile/Docker changes) | Docker build + push to Artifact Registry |
+| `deploy.yaml` | Push to dev/staging/main | Tag image, trigger scan |
+| `promote.yaml` | Push to dev/staging | Auto-promote to next branch |
+| `smoke-test.yaml` | Push to staging | Validate scan outputs in GCS |
 
 ## Security & Ethics
 

--- a/README.md
+++ b/README.md
@@ -1,28 +1,27 @@
-# Peregrine Penetrator
+# Peregrine Penetrator Scanner
 
 <!-- Badges -->
-[![Build status](https://badge.buildkite.com/3e8ca31d1b42f054f917dd33f13863ef90099294aa2b703484.svg)](https://buildkite.com/chaudhuri-and-co/peregrine-penetrator-scanner)
+[![Woodpecker CI](https://d3ci42.peregrinetechsys.net/api/badges/5/status.svg)](https://d3ci42.peregrinetechsys.net/repos/5)
 ![Ruby](https://img.shields.io/badge/ruby-3.2.2-CC342D?logo=ruby&logoColor=white)
-![Rails](https://img.shields.io/badge/rails-7.1-CC0000?logo=rubyonrails&logoColor=white)
-![Coverage](https://img.shields.io/badge/coverage-95.85%25-brightgreen)
+![Sequel](https://img.shields.io/badge/ORM-Sequel-blue)
+![Coverage](https://img.shields.io/badge/coverage-94.96%25-brightgreen)
 ![RuboCop](https://img.shields.io/badge/rubocop-0%20offenses-brightgreen)
 ![License](https://img.shields.io/badge/license-BSL%201.1-blue)
 ![Platform](https://img.shields.io/badge/platform-GCP-4285F4?logo=googlecloud&logoColor=white)
 
-Automated security scanning platform that orchestrates best-in-class open-source tools against target web applications, aggregates findings, and generates professional reports.
+Automated security scanning engine that orchestrates open-source penetration testing tools against target web applications, normalizes and deduplicates findings, enriches with CVE intelligence, and exports structured results to GCS and BigQuery.
 
-> **v0.1.0** — See [RELEASE_NOTES.md](RELEASE_NOTES.md) for what's new.
+> **v0.3.0** — See [RELEASE_NOTES.md](RELEASE_NOTES.md) for what's new.
 
 ### Project Scope (March 2026)
 
-| Metric | Count |
+| Metric | Value |
 |--------|-------|
-| Application code | 3,700 lines |
-| Test code | 5,141 lines |
-| Test:Code ratio | 1.39:1 |
-| Test examples | 413 |
-| Line coverage | 95.85% |
+| Application code | ~1,150 lines |
+| Test examples | 389 |
+| Line coverage | 94.96% |
 | RuboCop offenses | 0 |
+| Gems | 15 |
 
 ---
 
@@ -34,20 +33,38 @@ All tools in this repository are for **authorized testing only**. Explicit writt
 
 ## Architecture
 
-```
-Cloud Scheduler → Cloud Function → Ephemeral Spot VM → ScanOrchestrator
-Buildkite CI    → trigger-scan.sh ↗                      ├── Discovery (ffuf + Nikto)
-Dev CLI         → ./cloud/dev scan ↗                     ├── Active Scan (OWASP ZAP)
-                                                          └── Targeted (Nuclei + sqlmap)
-                                                               ↓
-                                              FindingNormalizer → CVE Enrichment
-                                                               ↓
-                                              AI Analysis (Claude) → BigQuery Log
-                                                               ↓
-                                              ReportGenerator (JSON/MD/HTML/PDF) → Notify
+The scanner is one component of a three-service platform:
 
-Cloud Scheduler (*/10) → vm-scavenger → SSH liveness check → delete orphans → Slack
+| Service | Responsibility |
+|---------|---------------|
+| **Scanner** (this repo) | Orchestrate tools, normalize findings, export JSON to GCS |
+| **Reporter** ([peregrine-penetrator-reporter](https://github.com/Peregrine-Technology-Systems/peregrine-penetrator-reporter)) | AI analysis, report generation (HTML/PDF), ticketing, email |
+| **Backend** | Orchestration API, scheduling, billing, notifications |
+
 ```
+Cloud Scheduler → Cloud Function → Ephemeral Spot VM → bin/scan
+                                                          ├── Phase 1: Discovery (ffuf + Nikto)
+                                                          ├── Phase 2: Active Scan (OWASP ZAP)
+                                                          └── Phase 3: Targeted (Nuclei + sqlmap)
+                                                               ↓
+                                                FindingNormalizer (SHA256 dedup)
+                                                               ↓
+                                                CveIntelligenceService (NVD, CISA KEV, EPSS, OSV)
+                                                               ↓
+                                                ScanResultsExporter → GCS (v1.0 JSON envelope)
+                                                               ↓
+                                                BigQueryLogger (findings + metadata + costs)
+                                                               ↓
+                                                ScanCallbackService → Backend API
+                                                               ↓
+                                                SlackNotifier → Webhook
+```
+
+### VM Lifecycle
+Scan VMs self-terminate on completion. A Cloud Function scavenger runs every 10 minutes as a safety net:
+- VMs < 30 min old: left alone
+- VMs 30 min – 4 hours: SSH liveness check — deletes only if no active scan
+- VMs > 4 hours: force-deleted regardless of state
 
 ## Security Tool Stack
 
@@ -71,24 +88,26 @@ Cloud Scheduler (*/10) → vm-scavenger → SSH liveness check → delete orphan
 git clone https://github.com/Peregrine-Technology-Systems/peregrine-penetrator-scanner.git
 cd peregrine-penetrator-scanner
 bundle install
-rails db:create db:migrate
 bundle exec rspec
 ```
 
-See [DEVELOPMENT.md](DEVELOPMENT.md) for full setup instructions, environment variables, and testing details.
+See [DEVELOPMENT.md](DEVELOPMENT.md) for full setup instructions and environment variables.
 
-### Docker
+### Run a Scan
 ```bash
-docker build --platform linux/amd64 -f docker/Dockerfile -t pentest-platform .
+# Via CLI
+bin/scan --profile quick --name "My App" --urls '["https://example.com"]'
 
-# Run a scan
+# Via environment variables (Docker/VM)
+SCAN_PROFILE=standard TARGET_NAME="My App" TARGET_URLS='["https://example.com"]' bin/scan
+
+# Via Docker
+docker build --platform linux/amd64 -f docker/Dockerfile -t scanner .
 docker run --platform linux/amd64 \
   -e SCAN_PROFILE=quick \
   -e TARGET_NAME="My App" \
   -e TARGET_URLS='["https://example.com"]' \
-  -e ANTHROPIC_API_KEY="sk-..." \
-  -v "$(pwd)/storage/reports:/app/storage/reports" \
-  pentest-platform rake scan:run
+  scanner
 ```
 
 ### Cloud Development
@@ -96,34 +115,9 @@ docker run --platform linux/amd64 \
 ./cloud/dev start          # Create/start GCP dev VM
 ./cloud/dev build          # Sync code + Docker build on VM
 ./cloud/dev scan quick     # Run scan, stream output
-./cloud/dev results        # Download reports locally
+./cloud/dev results        # Download results locally
 ./cloud/dev stop           # Stop VM (preserves Docker cache)
 ```
-
-### Production
-```bash
-./cloud/dev scan-prod      # On-demand production scan (ephemeral spot VM)
-# Scheduled: Cloud Scheduler triggers weekly Monday 2am UTC
-```
-
-### VM Lifecycle Management
-Scan VMs self-terminate on completion. A Cloud Function scavenger runs every 10 minutes as a safety net:
-- VMs < 30 min old: left alone
-- VMs 30 min – 4 hours: SSH liveness check — deletes only if no active scan container or VM is unreachable
-- VMs > 4 hours: force-deleted regardless of state
-- Slack notifications for all deletions with container info and reason
-
-```bash
-./cloud/dev scavenge       # Manual orphan cleanup
-```
-
-### Reports
-Reports are generated in JSON, Markdown, HTML, and PDF formats. PDF reports feature:
-- Branded title page with Peregrine falcon logo
-- Clickable table of contents with PDF bookmarks
-- CONFIDENTIAL watermark on content pages
-- Test methodology appendix with OWASP Top 10 mapping
-- Professional LaTeX typesetting via pandoc/xelatex
 
 ## Scan Profiles
 
@@ -133,6 +127,13 @@ Reports are generated in JSON, Markdown, HTML, and PDF formats. PDF reports feat
 | standard | ~30 min | ZAP full + Nuclei + Nikto + ffuf |
 | thorough | ~2 hours | All tools, deep crawl |
 
+## Key Design Decisions
+
+- **Sequel ORM** over Rails/ActiveRecord — 80MB RAM, <1s boot, 15 gems (was 300MB, 5s, 38 gems)
+- **Ephemeral VMs** — each scan runs on a fresh spot VM that self-terminates
+- **JSON-first pipeline** — canonical v1.0 JSON envelope exported to GCS, then loaded to BigQuery
+- **Separation of duties** — scanner scans, reporter reports, backend orchestrates
+
 ## Documentation
 
 | Document | Description |
@@ -140,13 +141,21 @@ Reports are generated in JSON, Markdown, HTML, and PDF formats. PDF reports feat
 | [docs/DESIGN.md](docs/DESIGN.md) | Architecture, data model, and design decisions |
 | [DEVELOPMENT.md](DEVELOPMENT.md) | Local setup, testing, environment configuration |
 | [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md) | GCP deployment, infrastructure, and operations |
+| [docs/schema_versioning.md](docs/schema_versioning.md) | v1.0 JSON envelope contract |
 | [RELEASE_NOTES.md](RELEASE_NOTES.md) | Version history and changelog |
 | [CONTRIBUTING.md](CONTRIBUTING.md) | Contribution guidelines |
-| [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) | Community standards and ethics |
 
-## Contributing
+## CI/CD
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
+CI runs on [Woodpecker CI](https://d3ci42.peregrinetechsys.net) (self-hosted). Pipelines:
+
+| Pipeline | Trigger | Steps |
+|----------|---------|-------|
+| `ci.yaml` | Push (all branches) | RSpec + RuboCop |
+| `build.yaml` | Push to development | Docker build + push to Artifact Registry |
+| `deploy.yaml` | Push to dev/staging/main | Tag image, trigger scan |
+| `promote.yaml` | Push to dev/staging | Auto-promote to next branch |
+| `smoke-test.yaml` | Push to staging | Validate scan outputs in GCS |
 
 ## License
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,25 +1,53 @@
 # Release Notes
 
-## Unreleased
+## v0.3.0 — 2026-03-23
 
-### Infrastructure
-- Migrate CI/CD from Buildkite to self-hosted Woodpecker CI — eliminates concurrency throttling and SaaS dependency (Issue #270)
+Major refactor: stripped scanner to its core responsibility. Report generation, AI analysis, ticketing, and email notifications extracted to dedicated services (reporter, backend).
+
+### Architecture — Separation of Duties
+- **Removed**: Report generation (JSON/HTML/Markdown/PDF), AI analysis (Claude API), ticketing (GitHub Issues), email notifications, Nuclei template generator (#245, #277)
+- **Removed gems**: grover, ruby-anthropic, mail — scanner now has 15 gems (was 38 under Rails)
+- **Removed Docker deps**: chromium, nodejs, npm, pandoc, texlive, puppeteer — image ~1GB smaller
+- **Scanner now does**: scan orchestration → CVE enrichment → JSON export to GCS → BigQuery logging → cost tracking → callback → Slack
+- See #278 for full inventory of removed code
+
+### Rails → Sequel Migration
+- Replaced Rails 7.1 with Sequel ORM + plain Ruby CLI (`bin/scan`) (#258, #268)
+- Boot time: <1s (was 3-5s), RAM: ~80MB (was ~300MB), gems: 15 (was 38)
+- Fresh Sequel migrations for targets, scans, findings (SQLite)
+- `spec/sequel_helper.rb` replaces `spec/rails_helper.rb` with DatabaseCleaner-sequel
+- All `Rails.root` → `Penetrator.root`, `Rails.logger` → `Penetrator.logger`
+
+### CI/CD — Woodpecker Migration
+- Migrate from Buildkite to self-hosted Woodpecker CI (#270, #275)
+- Pipelines: ci, build, deploy, promote, smoke-test, sync-back
+- Docker-wrapped test/lint steps (agent-independent)
+- Eliminated Buildkite concurrency throttling
+
+### Pipeline Fixes (#271-274)
+- Idempotent migrations via `Sequel::Migrator.is_current?` guard
+- Replace `rubocop-rails` with `rubocop-sequel` in lint config
+- Fix Sequel dataset `.size` calls (datasets have `.count`, not `.size`)
+- Fix serialization in-place mutation bug in TicketingService (use `.merge`)
+- Fix `findings_dataset` vs cached `findings` association in specs
+
+### Quality
+- 389 specs, 0 failures, 94.96% coverage, 0 RuboCop offenses
+- 20 focused open issues (was 50+) — 18 closed, 13 transferred to reporter repo
+
+## Unreleased
 
 ### Features
 - Scan cost tracking: ScanCostLogger logs per-scan cost metrics (VM runtime, tokens, API calls, GCS bytes) to BigQuery `scan_costs` table (#187)
-- Scan completion callback: ScanCallbackService POSTs scan summary, cost data, and report paths to backend API on scan completion (#186)
+- Scan completion callback: ScanCallbackService POSTs scan summary and cost data to backend API (#186)
 
 ### Bug Fixes
-- Pass TARGET_NAME env var through scan VMs so reports show actual target name instead of "Default Target" (#203)
-- Create pentest-anthropic-api-key in GCP Secret Manager so AI executive summary is generated (#202)
-- Restore Executive Summary heading and AI-generated text to PDF/HTML/Markdown reports; fix heading hierarchy (H1→H2→H3 proper nesting)
-- ReportGenerator no longer crashes entire scan when signed URL generation fails or a single report format fails — graceful degradation
-- StorageService falls back to local storage and local URLs when GCS bucket is inaccessible instead of crashing scan (#139)
-- Pass SCAN_MODE env var to Docker in scan VMs so BigQuery logs to correct table (#134)
+- Pass TARGET_NAME env var through scan VMs (#203)
+- StorageService falls back to local storage when GCS inaccessible (#139)
+- Pass SCAN_MODE env var to Docker in scan VMs (#134)
 - Orphan VM scavenger: auto-delete scan VMs older than 30 minutes (#146)
-- Scan VMs now pull environment-tagged Docker images (`:staging`/`:production`) instead of `:latest` (#148)
-- Repo renamed from `web-app-penetration-test` to `peregrine-penetrator`, then to `peregrine-penetrator-scanner` (#150, #247)
-- Report TOC: all major sections (Findings Summary, Detailed Findings, Test Methodology, Appendix) now at Level 1 (#154)
+- Scan VMs pull environment-tagged Docker images (#148)
+- Repo renamed to `peregrine-penetrator-scanner` (#150, #247)
 - Auto-assign repo owner as reviewer on staging→main promotion PRs (#161)
 
 ### Cloud Scheduler


### PR DESCRIPTION
## Summary

Updates all project documentation to reflect the current scanner scope after the v0.3.0 refactor.

- **README**: Sequel ORM, Woodpecker CI badge, three-service architecture diagram, stripped scope, updated metrics (389 specs, 94.96% coverage, 15 gems)
- **RELEASE_NOTES**: v0.3.0 section covering Rails→Sequel, Woodpecker CI, service extraction (-7,030 lines), pipeline fixes, issue cleanup
- **CLAUDE.md**: Updated architecture, Sequel ORM notes, directory layout, Woodpecker CI config

## Test plan

- [x] No code changes — docs only
- [x] 389 specs pass, 0 rubocop offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)