### PR TITLE
fix: remove Gemfile from Docker build trigger

### DIFF
--- a/.woodpecker/build.yaml
+++ b/.woodpecker/build.yaml
@@ -5,12 +5,6 @@ when:
     path:
       include:
         - "docker/Dockerfile"
-        - "Gemfile"
-        - "Gemfile.lock"
-      exclude:
-        - "docker/Dockerfile.base"
-        - "docker/base-versions.txt"
-        - "docker/wordlists/**"
 
 depends_on:
   - ci


### PR DESCRIPTION
## Summary

- Remove `Gemfile` and `Gemfile.lock` from `.woodpecker/build.yaml` path filter
- Docker image only rebuilds when `docker/Dockerfile` changes
- Gemfile changes handled by `bundle install` at VM boot, same as CI

## Why

A gem change doesn't require a new Docker image. The scan VM runs `bundle install` at boot. Rebuilding a Docker image for a Gemfile change wastes ~2min of CI time for no benefit.

## Test plan

- [ ] Push a Gemfile-only change → no Docker build triggers
- [ ] Push a `docker/Dockerfile` change → Docker build triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)