### PR TITLE
fix: remove gem installation from app Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,7 @@
-# Scanner app image — gems + application code
-# Built on every push to development
+# Scanner app image — application code only
+# Built only when this Dockerfile changes
 # Inherits security tools and runtime from scanner-base
+# Gems installed at VM boot via bundle install (not baked into image)
 ARG DOCKER_REGISTRY=us-central1-docker.pkg.dev/peregrine-pentest-dev/pentest
 FROM ${DOCKER_REGISTRY}/scanner-base:latest
 
@@ -9,17 +10,11 @@ ENV RUBY_YJIT_ENABLE=1
 
 WORKDIR /app
 
-# Install gems
-COPY Gemfile Gemfile.lock ./
-RUN bundle config set --local deployment true && \
-    bundle config set --local without 'development test' && \
-    bundle install --jobs 4
-
 # Copy application code
 COPY . .
 
 # Create necessary directories
 RUN mkdir -p tmp/scans tmp/reports storage/reports log custom_templates/nuclei
 
-# Database is created at boot (Penetrator.boot! runs migrations)
+# Gems installed at boot: bundle install --deployment --without development test
 CMD ["bin/scan"]


### PR DESCRIPTION
## Summary

Remove `COPY Gemfile` and `bundle install` from `docker/Dockerfile`. Since Gemfile changes don't trigger a Docker rebuild (#283), baking gems into the image creates version conflicts when the VM runs `bundle install` at boot.

## What changed

- Removed `COPY Gemfile Gemfile.lock` and `bundle install` from Dockerfile
- Image now contains only app code + directory structure
- Gems installed fresh at VM boot (via `vm-startup.sh`)

## Test plan

- [ ] VM boots, runs `bundle install`, executes `bin/scan` successfully
- [ ] No stale gems in image conflicting with Gemfile.lock

🤖 Generated with [Claude Code](https://claude.com/claude-code)