### PR TITLE
fix: update specs for hybrid Docker model

### DIFF
--- a/spec/cloud/docker_image_tags_spec.rb
+++ b/spec/cloud/docker_image_tags_spec.rb
@@ -15,8 +15,10 @@ RSpec.describe 'Docker image environment tagging' do # rubocop:disable RSpec/Des
   describe 'trigger-scan.sh' do
     let(:script) { File.read(File.join(project_root, 'scripts/woodpecker/trigger-scan.sh')) }
 
-    it 'uses environment name as image tag in metadata' do
-      expect(script).to match(/IMAGE_TAG=.*\$.*ENV/)
+    it 'maps each environment to a specific image tag' do
+      expect(script).to include('IMAGE_TAG="development"')
+      expect(script).to include('IMAGE_TAG="staging"')
+      expect(script).to include('IMAGE_TAG="production"')
     end
 
     it 'does not default to latest' do

--- a/spec/cloud/vm_startup_env_vars_spec.rb
+++ b/spec/cloud/vm_startup_env_vars_spec.rb
@@ -3,12 +3,12 @@
 RSpec.describe 'vm-startup.sh environment variables' do # rubocop:disable RSpec/DescribeClass
   let(:project_root) { File.expand_path('../..', __dir__) }
 
-  # All env vars that the Rails app reads and needs passed through docker run
+  # All env vars that the scanner needs passed through docker run
   let(:required_env_vars) do
     %w[
       SCAN_PROFILE
       SCAN_MODE
-      RAILS_ENV
+      APP_ENV
       TARGET_NAME
       TARGET_URLS
       ANTHROPIC_API_KEY
@@ -25,36 +25,29 @@ RSpec.describe 'vm-startup.sh environment variables' do # rubocop:disable RSpec/
     ]
   end
 
-  shared_examples 'passes all required env vars to docker run' do |script_path|
+  shared_examples 'passes all required env vars' do |script_path|
     let(:script) { File.read(File.join(project_root, script_path)) }
 
-    # Extract the docker run block
-    let(:docker_run_block) do
-      match = script.match(/docker run .+?rake scan:run/m)
-      expect(match).not_to be_nil, "Could not find 'docker run ... rake scan:run' block in #{script_path}"
-      match[0]
-    end
-
-    required_env_vars_method = :required_env_vars
-
-    it 'includes all required env vars in docker run' do
-      missing = send(required_env_vars_method).reject do |var|
-        docker_run_block.include?("-e \"#{var}=") ||
-          docker_run_block.include?("-e #{var}=") ||
-          docker_run_block.include?("-e \"#{var}")
+    it 'includes all required env vars' do
+      missing = required_env_vars.reject do |var|
+        # Check both inline -e and bash array formats
+        script.include?("-e \"#{var}=") ||
+          script.include?("-e #{var}=") ||
+          script.include?("-e \"#{var}\"") ||
+          script.include?("-e \"#{var}")
       end
 
       expect(missing).to be_empty,
-                         "Missing env vars in docker run: #{missing.join(', ')}. " \
-                         'The Rails app needs these but they are not passed through.'
+                         "Missing env vars: #{missing.join(', ')}. " \
+                         'The scanner needs these but they are not passed through.'
     end
   end
 
   describe 'cloud/lib/vm-startup.sh' do
-    include_examples 'passes all required env vars to docker run', 'cloud/lib/vm-startup.sh'
+    include_examples 'passes all required env vars', 'cloud/lib/vm-startup.sh'
   end
 
   describe 'cloud/scheduler/vm-startup.sh' do
-    include_examples 'passes all required env vars to docker run', 'cloud/scheduler/vm-startup.sh'
+    include_examples 'passes all required env vars', 'cloud/scheduler/vm-startup.sh'
   end
 end


### PR DESCRIPTION
## Summary

Update spec files that validate CI scripts to match the hybrid Docker model from PR #286.

- `docker_image_tags_spec.rb`: Check explicit IMAGE_TAG per environment (development/staging/production)
- `vm_startup_env_vars_spec.rb`: Check SCAN_ENV array format, APP_ENV instead of RAILS_ENV

These are the last 2 test failures blocking the pipeline.

## Test plan

- [ ] Pipeline passes CI (0 failures)
- [ ] Promote to staging triggers Docker build + scan

🤖 Generated with [Claude Code](https://claude.com/claude-code)