### PR TITLE
fix: add RELEASE_NOTES.md merge=union to .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,8 @@
 # See https://git-scm.com/docs/gitattributes for more about git attribute files.
 
+# Both sides' additions are kept automatically — no conflicts on promotions
+RELEASE_NOTES.md merge=union
+
 # Mark the database schema as having been generated.
 db/schema.rb linguist-generated
 


### PR DESCRIPTION
Standard conflict prevention for RELEASE_NOTES.md during branch promotions. Reporter already has this; scanner and backend were missing it.