### PR TITLE
fix: add PDF binary merge=ours to .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,6 +3,9 @@
 # Both sides' additions are kept automatically — no conflicts on promotions
 RELEASE_NOTES.md merge=union
 
+# Binary PDFs — on conflict, keep target branch version (develop-canonical flow)
+*.pdf binary merge=ours
+
 # Mark the database schema as having been generated.
 db/schema.rb linguist-generated
 


### PR DESCRIPTION
Prevents binary merge conflicts on PDF files during promotions.