### PR TITLE
fix: Slack shows repo name with yellow highlight

### DIFF
--- a/scripts/woodpecker/notify-status.sh
+++ b/scripts/woodpecker/notify-status.sh
@@ -9,7 +9,8 @@ if [ -z "${SLACK_WEBHOOK_URL:-}" ]; then
   exit 0
 fi
 
-REPO="${CI_REPO:-unknown}"
+REPO_FULL="${CI_REPO:-unknown}"
+REPO="${REPO_FULL##*/}"  # Strip org prefix — just the repo name
 BRANCH="${CI_COMMIT_BRANCH:-${CI_COMMIT_TAG:-unknown}}"
 COMMIT="${CI_COMMIT_SHA:0:7}"
 FULL_SHA="${CI_COMMIT_SHA:-}"
@@ -17,7 +18,8 @@ AUTHOR="${CI_COMMIT_AUTHOR:-unknown}"
 MESSAGE="${CI_COMMIT_MESSAGE:-no message}"
 STATUS="${CI_PIPELINE_STATUS:-unknown}"
 WOODPECKER_URL="https://d3ci42.peregrinetechsys.net/repos/${CI_REPO_ID:-0}/pipeline/${CI_PIPELINE_NUMBER:-0}"
-COMMIT_URL="https://github.com/${REPO}/commit/${FULL_SHA}"
+COMMIT_URL="https://github.com/${REPO_FULL}/commit/${FULL_SHA}"
+REPO_URL="https://github.com/${REPO_FULL}"
 
 # Truncate commit message to first line
 MESSAGE=$(echo "$MESSAGE" | head -1 | cut -c1-80)
@@ -47,13 +49,13 @@ else
   TITLE="CI passed (${BRANCH})"
 fi
 
-# Build the message
-DETAILS="*Repo:* ${REPO}\n*Branch:* ${BRANCH}\n*Commit:* <${COMMIT_URL}|\`${COMMIT}\`> — ${MESSAGE}\n*Author:* ${AUTHOR}"
+# Build the message — repo name linked, no org prefix
+DETAILS="*Branch:* ${BRANCH}\n*Commit:* <${COMMIT_URL}|\`${COMMIT}\`> — ${MESSAGE}\n*Author:* ${AUTHOR}"
 
 # Production releases get extra emphasis
 if [ "$BRANCH" = "main" ] && [ -f VERSION ]; then
   VERSION=$(cat VERSION | tr -d '[:space:]')
-  DETAILS="*Repo:* ${REPO}\n*Version:* \`v${VERSION}\`\n*Commit:* <${COMMIT_URL}|\`${COMMIT}\`> — ${MESSAGE}\n*Author:* ${AUTHOR}\n*Status:* Deployed to production"
+  DETAILS="*Version:* \`v${VERSION}\`\n*Commit:* <${COMMIT_URL}|\`${COMMIT}\`> — ${MESSAGE}\n*Author:* ${AUTHOR}\n*Status:* Deployed to production"
 fi
 
 # Production release gets a distinct, prominent message
@@ -73,7 +75,7 @@ if [ "$BRANCH" = "main" ] && [ -f VERSION ] && [ "$STATUS" != "failure" ]; then
           \"type\": \"section\",
           \"text\": {
             \"type\": \"mrkdwn\",
-            \"text\": \"*${REPO}* deployed to production\n\n*Version:* \`v${VERSION}\`\n*Commit:* <${COMMIT_URL}|\`${COMMIT}\`> — ${MESSAGE}\n*Author:* ${AUTHOR}\n*Pipeline:* <${WOODPECKER_URL}|View in Woodpecker>\"
+            \"text\": \":yellow_square: *<${REPO_URL}|${REPO}>* deployed to production\n\n*Version:* \`v${VERSION}\`\n*Commit:* <${COMMIT_URL}|\`${COMMIT}\`> — ${MESSAGE}\n*Author:* ${AUTHOR}\n*Pipeline:* <${WOODPECKER_URL}|View in Woodpecker>\"
           }
         },
         {\"type\": \"divider\"}
@@ -93,7 +95,7 @@ else
               \"type\": \"section\",
               \"text\": {
                 \"type\": \"mrkdwn\",
-                \"text\": \"${EMOJI} *${TITLE}* — <${WOODPECKER_URL}|View pipeline>\n${DETAILS}\"
+                \"text\": \"${EMOJI} *${TITLE}* :yellow_square: *<${REPO_URL}|${REPO}>*\n${DETAILS}\n<${WOODPECKER_URL}|View pipeline>\"
               }
             }
           ]


### PR DESCRIPTION
Strip org prefix, yellow marker for scanability.