### PR TITLE
fix: git push auth for version-bump and sync-back

### DIFF
--- a/scripts/woodpecker/sync-back.sh
+++ b/scripts/woodpecker/sync-back.sh
@@ -23,6 +23,9 @@ AUTH="Authorization: Bearer ${GH_TOKEN}"
 git config user.name "woodpecker-ci[bot]"
 git config user.email "woodpecker-ci[bot]@users.noreply.github.com"
 
+# Set push URL with token (Woodpecker clone uses HTTPS without push credentials)
+git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git"
+
 for BRANCH in development staging; do
   SYNC_BRANCH="sync/version-${VERSION}-to-${BRANCH}"
 

--- a/scripts/woodpecker/version-bump.sh
+++ b/scripts/woodpecker/version-bump.sh
@@ -81,6 +81,9 @@ fi
 git config user.name "woodpecker-ci[bot]"
 git config user.email "woodpecker-ci[bot]@users.noreply.github.com"
 
+# Set push URL with token (Woodpecker clone uses HTTPS without push credentials)
+git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git"
+
 git add VERSION RELEASE_NOTES.md
 git commit -m "release: ${TAG}
 


### PR DESCRIPTION
Woodpecker HTTPS clone has no push creds. Set remote URL with x-access-token.