### PR TITLE
fix: version-bump sends correct version in Slack (#309)

### DIFF
--- a/.woodpecker/version-bump.yaml
+++ b/.woodpecker/version-bump.yaml
@@ -21,6 +21,8 @@ steps:
         from_secret: gh_token
       DOCKER_REGISTRY:
         from_secret: docker_registry
+      SLACK_WEBHOOK_URL:
+        from_secret: slack_webhook_url
     commands:
       - scripts/woodpecker/version-bump.sh
 

--- a/scripts/woodpecker/version-bump.sh
+++ b/scripts/woodpecker/version-bump.sh
@@ -112,4 +112,35 @@ if [ -n "${DOCKER_REGISTRY:-}" ]; then
     "${DOCKER_REGISTRY}/scanner:production" 2>/dev/null || echo "WARNING: Could not tag scanner:production"
 fi
 
+# Send the production release Slack notification directly (notify-status would
+# read stale CI_COMMIT_MESSAGE from the triggering merge, not from our release commit)
+if [ -n "${SLACK_WEBHOOK_URL:-}" ]; then
+  COMMIT_URL="https://github.com/${REPO}/commit/$(git rev-parse HEAD)"
+  SHORT_SHA=$(git rev-parse --short HEAD)
+  WOODPECKER_URL="https://d3ci42.peregrinetechsys.net/repos/${CI_REPO_ID:-0}/pipeline/${CI_PIPELINE_NUMBER:-0}"
+  REPO_NAME="${REPO##*/}"
+  REPO_URL="https://github.com/${REPO}"
+
+  curl -s -X POST "$SLACK_WEBHOOK_URL" \
+    -H "Content-Type: application/json" \
+    -d "{
+      \"text\": \":rocket::rocket::rocket: PRODUCTION RELEASE ${TAG} — ${REPO_NAME}\",
+      \"blocks\": [
+        {\"type\": \"divider\"},
+        {
+          \"type\": \"header\",
+          \"text\": {\"type\": \"plain_text\", \"text\": \":rocket: PRODUCTION RELEASE ${TAG}\", \"emoji\": true}
+        },
+        {
+          \"type\": \"section\",
+          \"text\": {
+            \"type\": \"mrkdwn\",
+            \"text\": \"*<${REPO_URL}|${REPO_NAME}>* deployed to production\n\n*Version:* \`${TAG}\`\n*Commit:* <${COMMIT_URL}|\`${SHORT_SHA}\`> — release: ${TAG}\n*Bump:* ${BUMP_TYPE} (${CURRENT} → ${NEW_VERSION})\n*Pipeline:* <${WOODPECKER_URL}|View in Woodpecker>\"
+          }
+        },
+        {\"type\": \"divider\"}
+      ]
+    }" || echo "Warning: Slack notification failed"
+fi
+
 echo "=== Release ${TAG} complete ==="


### PR DESCRIPTION
VERSION on disk and CI_COMMIT_MESSAGE were out of sync. version-bump now sends gold notification directly.