### PR TITLE
fix: remove Docker clone plugin from local backend (#309)

### DIFF
--- a/.woodpecker/build.yaml
+++ b/.woodpecker/build.yaml
@@ -7,12 +7,6 @@ when:
 depends_on:
   - ci
 
-clone:
-  - name: clone
-    image: woodpeckerci/plugin-git
-    settings:
-      depth: 0
-
 labels:
   platform: linux
   backend: local

--- a/.woodpecker/version-bump.yaml
+++ b/.woodpecker/version-bump.yaml
@@ -3,12 +3,6 @@ when:
   - event: push
     branch: main
 
-clone:
-  - name: clone
-    image: woodpeckerci/plugin-git
-    settings:
-      depth: 0
-
 labels:
   platform: linux
   backend: local

--- a/scripts/woodpecker/version-bump.sh
+++ b/scripts/woodpecker/version-bump.sh
@@ -28,6 +28,9 @@ if echo "$COMMIT_MSG" | grep -qE '^release: v[0-9]'; then
   exit 0
 fi
 
+# Unshallow clone to access tags (Woodpecker clones with --depth 1)
+git fetch --unshallow 2>/dev/null || git fetch --tags 2>/dev/null || true
+
 # Read current version
 if [ ! -f VERSION ]; then
   echo "ERROR: VERSION file not found"


### PR DESCRIPTION
Docker clone plugin fails on local backend. Use default clone + git fetch --unshallow.