### PR TITLE
feat: per-environment Cloud Functions (#427)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -12,6 +12,7 @@
 - feat: add `deep` scan profile as alias for `thorough` (Reporter API compatibility)
 - fix: sync scheduler vm-startup.sh with authoritative cloud/lib/vm-startup.sh (control plane env vars)
 - feat: smoke test script for trigger_scan Cloud Function deployment verification (#413)
+- feat: per-environment Cloud Functions — trigger_development, trigger_staging, trigger_production (#427)
 
 ## v0.3.1 — 2026-03-23
 

--- a/cloud/scheduler/main.py
+++ b/cloud/scheduler/main.py
@@ -174,29 +174,56 @@ def scavenge_vms(request):
     return summary, 200
 
 
+def trigger_development(request):
+    """Launch a scan VM in development mode (clone at boot)."""
+    return _trigger_scan(request, default_mode='development',
+                         default_tag='development')
+
+
+def trigger_staging(request):
+    """Launch a scan VM in staging mode (baked image)."""
+    return _trigger_scan(request, default_mode='staging',
+                         default_tag='staging')
+
+
+def trigger_production(request):
+    """Launch a scan VM in production mode (baked image, spot pricing)."""
+    return _trigger_scan(request, default_mode='production',
+                         default_tag='production')
+
+
 def trigger_scan(request):
-    """HTTP Cloud Function to launch a scan VM.
+    """Backward-compatible entry point (Cloud Scheduler, legacy callers).
+
+    Defaults to production mode when scan_mode is not specified.
+    """
+    return _trigger_scan(request, default_mode='production',
+                         default_tag='production')
+
+
+def _trigger_scan(request, default_mode, default_tag):
+    """Internal: launch a scan VM.
 
     Accepts optional JSON body from Reporter dispatch:
       - scan_uuid, profile, target_url, target_name, target_urls
       - callback_url, job_id, reporter_base_url
-      - scan_mode, image_tag
+      - scan_mode, image_tag (override defaults from the environment function)
 
-    All fields fall back to defaults when omitted (backward compatible
-    with Cloud Scheduler which sends no body).
+    The per-environment function sets sensible defaults; the caller can
+    override scan_mode/image_tag if needed (e.g., to control scan depth).
     """
     data = request.get_json(silent=True) or {}
 
     scan_uuid = data.get('scan_uuid', f'scan-{int(time.time())}')
     profile = data.get('profile', 'standard')
+    scan_mode = data.get('scan_mode', default_mode)
+    image_tag = data.get('image_tag', default_tag)
     target_url = data.get('target_url',
                           'https://auxscan.app.data-estate.cloud')
     target_name = data.get('target_name', 'AuxScan Production')
     callback_url = data.get('callback_url', '')
     job_id = data.get('job_id', '')
     reporter_base_url = data.get('reporter_base_url', '')
-    scan_mode = data.get('scan_mode', 'production')
-    image_tag = data.get('image_tag', 'production')
 
     # Wrap single URL into JSON array for TARGET_URLS
     target_urls = data.get('target_urls')
@@ -217,6 +244,15 @@ def trigger_scan(request):
         startup_script = f.read()
 
     client = compute_v1.InstancesClient()
+
+    # Production uses spot pricing for ~60% cost savings
+    if scan_mode == 'production':
+        scheduling = compute_v1.Scheduling(
+            provisioning_model='SPOT',
+            instance_termination_action='DELETE',
+        )
+    else:
+        scheduling = compute_v1.Scheduling()
 
     instance = compute_v1.Instance(
         name=instance_name,
@@ -263,10 +299,7 @@ def trigger_scan(request):
             compute_v1.Items(key='IMAGE_TAG', value=image_tag),
             compute_v1.Items(key='startup-script', value=startup_script),
         ]),
-        scheduling=compute_v1.Scheduling(
-            provisioning_model='SPOT',
-            instance_termination_action='DELETE',
-        ),
+        scheduling=scheduling,
         labels={
             'env': scan_mode,
             'project': 'pentest',

--- a/cloud/scheduler/test_main.py
+++ b/cloud/scheduler/test_main.py
@@ -351,5 +351,112 @@ class TestTriggerScan(unittest.TestCase):
         self.assertEqual(instance.labels['profile'], 'deep')
 
 
+class TestPerEnvironmentFunctions(unittest.TestCase):
+    """Per-environment wrappers insulate callers from VM internals."""
+
+    def _make_request(self, body=None):
+        request = MagicMock()
+        request.get_json.return_value = body
+        return request
+
+    @patch('builtins.open', unittest.mock.mock_open(read_data='#!/bin/bash'))
+    @patch('main.compute_v1.InstancesClient')
+    def test_trigger_development_sets_development_mode(self, mock_cls):
+        client = MagicMock()
+        mock_cls.return_value = client
+        client.insert.return_value = MagicMock()
+
+        main.trigger_development(self._make_request({'profile': 'quick'}))
+
+        instance = client.insert.call_args[1]['instance_resource']
+        md = {i.key: i.value for i in instance.metadata.items}
+        self.assertEqual(md['SCAN_MODE'], 'development')
+        self.assertEqual(md['IMAGE_TAG'], 'development')
+
+    @patch('builtins.open', unittest.mock.mock_open(read_data='#!/bin/bash'))
+    @patch('main.compute_v1.InstancesClient')
+    def test_trigger_staging_sets_staging_mode(self, mock_cls):
+        client = MagicMock()
+        mock_cls.return_value = client
+        client.insert.return_value = MagicMock()
+
+        main.trigger_staging(self._make_request({'profile': 'standard'}))
+
+        instance = client.insert.call_args[1]['instance_resource']
+        md = {i.key: i.value for i in instance.metadata.items}
+        self.assertEqual(md['SCAN_MODE'], 'staging')
+        self.assertEqual(md['IMAGE_TAG'], 'staging')
+
+    @patch('builtins.open', unittest.mock.mock_open(read_data='#!/bin/bash'))
+    @patch('main.compute_v1.InstancesClient')
+    def test_trigger_production_sets_production_mode(self, mock_cls):
+        client = MagicMock()
+        mock_cls.return_value = client
+        client.insert.return_value = MagicMock()
+
+        main.trigger_production(self._make_request(None))
+
+        instance = client.insert.call_args[1]['instance_resource']
+        md = {i.key: i.value for i in instance.metadata.items}
+        self.assertEqual(md['SCAN_MODE'], 'production')
+        self.assertEqual(md['IMAGE_TAG'], 'production')
+
+    @patch('builtins.open', unittest.mock.mock_open(read_data='#!/bin/bash'))
+    @patch('main.compute_v1.InstancesClient')
+    def test_production_uses_spot_pricing(self, mock_cls):
+        client = MagicMock()
+        mock_cls.return_value = client
+        client.insert.return_value = MagicMock()
+
+        main.trigger_production(self._make_request(None))
+
+        instance = client.insert.call_args[1]['instance_resource']
+        self.assertEqual(instance.scheduling.provisioning_model, 'SPOT')
+
+    @patch('builtins.open', unittest.mock.mock_open(read_data='#!/bin/bash'))
+    @patch('main.compute_v1.InstancesClient')
+    def test_staging_does_not_use_spot_pricing(self, mock_cls):
+        client = MagicMock()
+        mock_cls.return_value = client
+        client.insert.return_value = MagicMock()
+
+        main.trigger_staging(self._make_request(None))
+
+        instance = client.insert.call_args[1]['instance_resource']
+        self.assertNotEqual(
+            getattr(instance.scheduling, 'provisioning_model', None),
+            'SPOT',
+        )
+
+    @patch('builtins.open', unittest.mock.mock_open(read_data='#!/bin/bash'))
+    @patch('main.compute_v1.InstancesClient')
+    def test_caller_can_override_scan_mode(self, mock_cls):
+        client = MagicMock()
+        mock_cls.return_value = client
+        client.insert.return_value = MagicMock()
+
+        # Caller overrides scan_mode on a production endpoint
+        request = self._make_request({'scan_mode': 'staging'})
+        main.trigger_production(request)
+
+        instance = client.insert.call_args[1]['instance_resource']
+        md = {i.key: i.value for i in instance.metadata.items}
+        self.assertEqual(md['SCAN_MODE'], 'staging')
+
+    @patch('builtins.open', unittest.mock.mock_open(read_data='#!/bin/bash'))
+    @patch('main.compute_v1.InstancesClient')
+    def test_profile_passed_through_to_vm(self, mock_cls):
+        client = MagicMock()
+        mock_cls.return_value = client
+        client.insert.return_value = MagicMock()
+
+        request = self._make_request({'profile': 'deep'})
+        main.trigger_production(request)
+
+        instance = client.insert.call_args[1]['instance_resource']
+        md = {i.key: i.value for i in instance.metadata.items}
+        self.assertEqual(md['SCAN_PROFILE'], 'deep')
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/spec/cloud/docker_image_tags_spec.rb
+++ b/spec/cloud/docker_image_tags_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe 'Docker image environment tagging' do # rubocop:disable RSpec/Des
     let(:script) { File.read(File.join(project_root, 'cloud/scheduler/main.py')) }
 
     it 'defaults image tag to production' do
-      expect(script).to include("'image_tag', 'production'")
+      expect(script).to include("default_tag='production'")
     end
   end
 end


### PR DESCRIPTION
## Summary

- Three environment-specific Cloud Function entry points: `trigger_development`, `trigger_staging`, `trigger_production`
- Each sets `scan_mode` and `image_tag` defaults for its environment
- Caller passes scan-specific params (`profile`, `target_url`, `scan_uuid`, etc.)
- Caller **can** override `scan_mode`/`image_tag` if needed
- Production uses spot pricing; staging/development use on-demand
- Backward-compatible `trigger_scan` preserved for Cloud Scheduler

Closes #427

## Deploy commands

```bash
for ENTRY in trigger_development trigger_staging trigger_production; do
  gcloud functions deploy "trigger-scan-${ENTRY#trigger_}" \
    --source=cloud/scheduler/ \
    --entry-point="$ENTRY" \
    --runtime=python312 \
    --trigger-http \
    --region=us-central1 \
    --project=peregrine-pentest-dev \
    --memory=512MB
done
```

## Test plan

- [x] 438 RSpec examples, 0 failures, 93.12% coverage
- [x] 0 RuboCop offenses
- [x] Python tests: mode/tag defaults, spot pricing, caller override, profile passthrough
- [ ] Deploy and verify with Reporter (reporter#345)

🤖 Generated with [Claude Code](https://claude.com/claude-code)