### PR TITLE
fix: cleanup stale smoke test VMs after every pipeline run (#520)

### DIFF
--- a/.woodpecker/smoke-test.yaml
+++ b/.woodpecker/smoke-test.yaml
@@ -24,3 +24,14 @@ steps:
     commands:
       - scripts/woodpecker/smoke-test.sh
     failure: ignore
+
+  - name: cleanup-smoke-vms
+    image: bash
+    environment:
+      GCP_PROJECT_DEV:
+        from_secret: gcp_project_dev
+    commands:
+      - scripts/woodpecker/cleanup-smoke-vms.sh
+    when:
+      - status: [success, failure]
+    depends_on: [smoke-test]

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix: cleanup stale smoke test VMs after every smoke-test pipeline run (#520)
+
 ## v0.3.1 — 2026-03-23
 
 - feat: populate CVSS scores, vectors, and EPSS data per finding (#521)

--- a/scripts/woodpecker/cleanup-smoke-vms.sh
+++ b/scripts/woodpecker/cleanup-smoke-vms.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Delete stale smoke test VMs older than MAX_AGE_MINUTES
+# Runs after every smoke test (success or failure) to prevent orphaned VMs
+
+BRANCH="${CI_COMMIT_BRANCH:-staging}"
+GCP_PROJECT="${GCP_PROJECT_DEV:?GCP_PROJECT_DEV not set}"
+MAX_AGE_MINUTES="${MAX_AGE_MINUTES:-10}"
+
+VM_PREFIX="pentest-scan-${BRANCH}-"
+echo "=== Cleanup: stale smoke test VMs (prefix: ${VM_PREFIX}, max age: ${MAX_AGE_MINUTES}m) ==="
+
+CUTOFF=$(date -u -d "-${MAX_AGE_MINUTES} minutes" +%Y-%m-%dT%H:%M:%S 2>/dev/null \
+  || date -u -v-${MAX_AGE_MINUTES}M +%Y-%m-%dT%H:%M:%S)
+
+VMS=$(gcloud compute instances list \
+  --filter="name~${VM_PREFIX} AND creationTimestamp<${CUTOFF}" \
+  --project="${GCP_PROJECT}" \
+  --format="value(name,zone)" 2>/dev/null || echo "")
+
+if [ -z "$VMS" ]; then
+  echo "No stale VMs found."
+  exit 0
+fi
+
+DELETED=0
+while IFS=$'\t' read -r NAME ZONE; do
+  echo "Deleting stale VM: ${NAME} (zone: ${ZONE})"
+  gcloud compute instances delete "$NAME" \
+    --project="${GCP_PROJECT}" --zone="${ZONE}" --quiet 2>&1 || true
+  DELETED=$((DELETED + 1))
+done <<< "$VMS"
+
+echo "Cleaned up ${DELETED} stale VM(s)."


### PR DESCRIPTION
## Summary

- New `cleanup-smoke-vms` step in smoke-test pipeline — runs on success AND failure
- Deletes any smoke test VMs older than 10 minutes matching the branch prefix
- New `scripts/woodpecker/cleanup-smoke-vms.sh` — portable across environments

## Test plan

- [x] 490 examples, 0 failures, 93.17% coverage
- [x] 0 rubocop offenses
- [ ] Verify cleanup step runs after smoke-test on next staging deploy

Closes #520

🤖 Generated with [Claude Code](https://claude.com/claude-code)