### PR TITLE
fix: VM timeout + scavenger OIDC auth + failure alerting (#547)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,9 @@
 ## Unreleased
 
 - fix: cleanup stale smoke test VMs after every smoke-test pipeline run (#520)
+- fix: add 1-hour timeout to docker run preventing hung scans from orphaning VMs (#547)
+- fix: scavenger Cloud Function OIDC auth — add run.invoker role and explicit audience (#547)
+- fix: scavenger alerts Slack on failure instead of silently swallowing errors (#547)
 
 ## v0.3.1 — 2026-03-23
 

--- a/cloud/scheduler/main.py
+++ b/cloud/scheduler/main.py
@@ -90,6 +90,20 @@ def scavenge_vms(request):
       - If no container or SSH fails: delete (hung/idle)
     - VMs older than HARD_MAX_MINUTES: delete unconditionally
     """
+    try:
+        summary = _scavenge_vms_inner()
+        return summary, 200
+    except Exception as e:
+        _slack_notify(
+            f':rotating_light: *VM scavenger failed* — orphaned VMs '
+            f'will NOT be cleaned up until this is fixed.\n'
+            f'Error: `{e}`'
+        )
+        return f'ERROR: {e}', 500
+
+
+def _scavenge_vms_inner():
+    """Core scavenger logic, separated for error handling."""
     hard_max_minutes = int(os.environ.get('HARD_MAX_MINUTES', '240'))
     client = compute_v1.InstancesClient()
     now = datetime.now(timezone.utc)
@@ -170,8 +184,7 @@ def scavenge_vms(request):
     if parts:
         _slack_notify('\n\n'.join(parts))
 
-    summary = f'Deleted: {len(deleted)}, Skipped: {len(skipped)}'
-    return summary, 200
+    return f'Deleted: {len(deleted)}, Skipped: {len(skipped)}'
 
 
 def trigger_development(request):

--- a/cloud/scheduler/vm-startup.sh
+++ b/cloud/scheduler/vm-startup.sh
@@ -127,6 +127,9 @@ case "$SCAN_MODE" in
     RESULTS_DIR="/tmp/scan-results"
     mkdir -p "${RESULTS_DIR}"
 
+    # Max scan duration — prevents hung scans from blocking self-termination
+    SCAN_TIMEOUT="${SCAN_TIMEOUT:-3600}"  # 1 hour default
+
     SCAN_EXIT=0
 
     # Dual-mode execution:
@@ -146,15 +149,16 @@ case "$SCAN_MODE" in
       echo "Cloning repo (branch: development)..."
       git clone --depth 1 --branch development "${REPO_URL}" "${APP_DIR}"
 
-      echo "Running ${SCAN_PROFILE} scan..."
-      docker run --rm \
-        "${SCAN_ENV[@]}" \
-        -v "${APP_DIR}:/app" \
-        -v "${RESULTS_DIR}:/app/storage/reports" \
-        --name "pentest-scan-$(date +%Y%m%d-%H%M%S)" \
-        "${BASE_IMAGE}" \
-        bash -c "cd /app && bundle install --deployment --without development test --jobs 4 --quiet && bundle exec bin/scan" \
-        || SCAN_EXIT=$?
+      echo "Running ${SCAN_PROFILE} scan (timeout: ${SCAN_TIMEOUT}s)..."
+      timeout --signal=TERM --kill-after=60 "${SCAN_TIMEOUT}" \
+        docker run --rm \
+          "${SCAN_ENV[@]}" \
+          -v "${APP_DIR}:/app" \
+          -v "${RESULTS_DIR}:/app/storage/reports" \
+          --name "pentest-scan-$(date +%Y%m%d-%H%M%S)" \
+          "${BASE_IMAGE}" \
+          bash -c "cd /app && bundle install --deployment --without development test --jobs 4 --quiet && bundle exec bin/scan" \
+          || SCAN_EXIT=$?
     else
       # --- Image mode: pull baked image (staging or production) ---
       FULL_IMAGE="${REGISTRY}/scanner:${IMAGE_TAG}"
@@ -164,18 +168,21 @@ case "$SCAN_MODE" in
 
       docker pull "${FULL_IMAGE}"
 
-      echo "Running ${SCAN_PROFILE} scan..."
-      docker run --rm \
-        "${SCAN_ENV[@]}" \
-        -v "${RESULTS_DIR}:/app/storage/reports" \
-        --name "pentest-scan-$(date +%Y%m%d-%H%M%S)" \
-        "${FULL_IMAGE}" \
-        bundle exec bin/scan \
-        || SCAN_EXIT=$?
+      echo "Running ${SCAN_PROFILE} scan (timeout: ${SCAN_TIMEOUT}s)..."
+      timeout --signal=TERM --kill-after=60 "${SCAN_TIMEOUT}" \
+        docker run --rm \
+          "${SCAN_ENV[@]}" \
+          -v "${RESULTS_DIR}:/app/storage/reports" \
+          --name "pentest-scan-$(date +%Y%m%d-%H%M%S)" \
+          "${FULL_IMAGE}" \
+          bundle exec bin/scan \
+          || SCAN_EXIT=$?
     fi
 
     if [ "$SCAN_EXIT" -eq 0 ]; then
       echo "Scan completed successfully"
+    elif [ "$SCAN_EXIT" -eq 124 ]; then
+      echo "ERROR: Scan timed out after ${SCAN_TIMEOUT}s — docker run killed"
     else
       echo "Scan failed with exit code ${SCAN_EXIT}"
     fi

--- a/infra/main.rb
+++ b/infra/main.rb
@@ -158,6 +158,14 @@ scavenger_function = Gcp::CloudFunctionsV2::Function.new("vm-scavenger",
   }
 )
 
+# Grant Cloud Run invoker so scheduler can call the scavenger function
+Gcp::CloudRunV2::ServiceIamMember.new("scavenger-invoker",
+  name: scavenger_function.service_config.apply { |sc| sc.service },
+  location: region,
+  role: "roles/run.invoker",
+  member: scanner_sa.email.apply { |e| "serviceAccount:#{e}" }
+)
+
 # Cloud Scheduler — VM scavenger every 10 minutes
 scavenger_schedule = Gcp::CloudScheduler::Job.new("vm-scavenger-schedule",
   name: "vm-scavenger-schedule",
@@ -168,7 +176,8 @@ scavenger_schedule = Gcp::CloudScheduler::Job.new("vm-scavenger-schedule",
     uri: scavenger_function.service_config.apply { |sc| sc.uri },
     http_method: "POST",
     oidc_token: {
-      service_account_email: scanner_sa.email
+      service_account_email: scanner_sa.email,
+      audience: scavenger_function.service_config.apply { |sc| sc.uri }
     }
   }
 )


### PR DESCRIPTION
## Summary

- Add `timeout 3600` (1 hour) to `docker run` in `vm-startup.sh` — hung scans now get killed and the EXIT trap fires, triggering self-termination
- Grant `roles/run.invoker` on the scavenger Cloud Function and set explicit OIDC `audience` in the scheduler config — fixes broken auth that silently prevented scavenger from running for 3+ days
- Wrap `scavenge_vms()` in try/except that alerts Slack on failure — no more silent failures

## Test plan

- [ ] `bundle exec rspec` — 490 tests pass, 93.17% coverage
- [ ] `bundle exec rubocop` — 0 offenses
- [ ] After merge + deploy: run `pulumi up` to apply IAM + scheduler changes
- [ ] Verify scavenger runs successfully: `gcloud functions logs read vm-scavenger --project=peregrine-pentest-dev --limit=5`
- [ ] Verify timeout works: check `vm-startup.sh` logs show timeout duration in scan startup message

🤖 Generated with [Claude Code](https://claude.com/claude-code)