### PR TITLE
chore: promotion pipeline uses local merge branch (#578)

### DIFF
--- a/.woodpecker/promote.yaml
+++ b/.woodpecker/promote.yaml
@@ -1,4 +1,4 @@
-# Branch promotion — development→staging (auto), staging→main (manual)
+# Branch promotion — development→staging (auto-merge), staging→main (manual review PR)
 when:
   - event: push
     branch: [development, staging]
@@ -9,6 +9,12 @@ depends_on:
 labels:
   platform: linux
   backend: local
+
+clone:
+  - name: clone
+    image: woodpeckerci/plugin-git
+    settings:
+      depth: 0
 
 steps:
   - name: promote
@@ -27,5 +33,5 @@ steps:
     commands:
       - scripts/woodpecker/notify-status.sh
     when:
-      - status: [success, failure]
+      - status: [failure]
     depends_on: [promote]

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- chore: promotion pipeline uses local merge branch — eliminates RELEASE_NOTES conflicts and cascading version bumps (#578)
+
 ## v0.13.2 — 2026-04-02
 
 ## v0.13.0 — 2026-04-02

--- a/scripts/woodpecker/promote.sh
+++ b/scripts/woodpecker/promote.sh
@@ -1,12 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Branch promotion via GitHub REST API (no gh CLI dependency)
+# Branch promotion via local merge branch
+# Always merges locally (respects .gitattributes merge=union for RELEASE_NOTES)
+# then pushes merge branch and creates PR
+#
 # development → staging: auto-merge
 # staging → main: manual review
 
 REPO="Peregrine-Technology-Systems/peregrine-penetrator-scanner"
-ORG="Peregrine-Technology-Systems"
 API="https://api.github.com"
 BRANCH="${CI_COMMIT_BRANCH}"
 
@@ -24,32 +26,107 @@ case "$BRANCH" in
   *)           echo "No promotion for branch: $BRANCH"; exit 0 ;;
 esac
 
-# Check for existing open PR
+# ── Guard: skip if this push is itself a sync-back or release commit ──
+COMMIT_MSG="${CI_COMMIT_MESSAGE:-}"
+if echo "$COMMIT_MSG" | grep -qiE '^Sync:'; then
+  echo "Skipping promotion — triggered by sync-back commit"
+  exit 0
+fi
+if echo "$COMMIT_MSG" | grep -qE '^release: v[0-9]'; then
+  echo "Skipping promotion — triggered by release commit"
+  exit 0
+fi
+
+# ── Guard: skip if sync-back or release PRs are in flight ──
+INFLIGHT=$(curl -s -H "$AUTH" \
+  "${API}/repos/${REPO}/pulls?state=open&per_page=100" \
+  | jq '[.[] | select(
+      (.title | test("^Sync:"))
+      or (.head.ref | test("^release/"))
+    )] | length')
+
+if [ "$INFLIGHT" -gt 0 ]; then
+  echo "Skipping promotion — ${INFLIGHT} sync-back or release PR(s) still open"
+  exit 0
+fi
+
+# ── Guard: skip if promotion PR already exists ──
+MERGE_BRANCH="merge/${BRANCH}-to-${BASE}"
 EXISTING=$(curl -s -H "$AUTH" \
-  "${API}/repos/${REPO}/pulls?base=${BASE}&head=${ORG}:${BRANCH}&state=open" \
-  | jq 'length // 0')
+  "${API}/repos/${REPO}/pulls?base=${BASE}&state=open" \
+  | jq "[.[] | select(
+      (.head.ref == \"${BRANCH}\")
+      or (.head.ref == \"${MERGE_BRANCH}\")
+    )] | length")
 
 if [ "$EXISTING" -gt 0 ]; then
   echo "Promotion PR already exists (${BRANCH} → ${BASE})"
   exit 0
 fi
 
-# Check for new commits via GitHub API (git rev-list fails in Woodpecker's shallow clone)
+# ── Guard: skip if no new commits ──
 COMPARE=$(curl -s -H "$AUTH" "${API}/repos/${REPO}/compare/${BASE}...${BRANCH}" | jq -r '.ahead_by // 0')
 if [ "$COMPARE" = "0" ]; then
   echo "No new commits to promote (${BRANCH} is up to date with ${BASE})"
   exit 0
 fi
-COMMITS="$COMPARE"
 
-# Create PR
-echo "Creating promotion PR: ${BRANCH} → ${BASE} (${COMMITS} commits)"
+echo "Promoting ${BRANCH} → ${BASE} (${COMPARE} commits)"
+
+# ── Create local merge branch ──
+git config user.name "woodpecker-ci[bot]"
+git config user.email "woodpecker-ci[bot]@users.noreply.github.com"
+git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git"
+
+git fetch --unshallow origin 2>/dev/null || true
+git fetch origin "$BRANCH" "$BASE"
+git checkout -b "$MERGE_BRANCH" "origin/${BASE}"
+
+if git merge "origin/${BRANCH}" --no-edit 2>/dev/null; then
+  echo "Merge succeeded cleanly"
+  # Skip if merge produced no file changes (trees identical despite commit count)
+  if [ "$(git rev-parse HEAD^{tree})" = "$(git rev-parse "origin/${BASE}^{tree}")" ]; then
+    echo "No file changes after merge — trees identical, skipping promotion"
+    exit 0
+  fi
+else
+  # Auto-resolve RELEASE_NOTES.md — keep source branch version
+  if git diff --name-only --diff-filter=U | grep -q 'RELEASE_NOTES.md'; then
+    echo "Auto-resolving RELEASE_NOTES.md — keeping ${BRANCH} content"
+    git checkout "origin/${BRANCH}" -- RELEASE_NOTES.md
+    git add RELEASE_NOTES.md
+  fi
+
+  # Fail on any remaining conflicts
+  REMAINING=$(git diff --name-only --diff-filter=U 2>/dev/null || true)
+  if [ -n "$REMAINING" ]; then
+    echo "ERROR: Unresolvable conflicts in: ${REMAINING}"
+    git merge --abort
+    exit 1
+  fi
+
+  git commit --no-edit
+fi
+
+# Dedup ## Unreleased headers (safety net for merge=union artifacts)
+if [ -f RELEASE_NOTES.md ]; then
+  DUPES=$(grep -c '^## Unreleased$' RELEASE_NOTES.md || true)
+  if [ "$DUPES" -gt 1 ]; then
+    awk '!seen[$0]++ || !/^## Unreleased$/' RELEASE_NOTES.md > RELEASE_NOTES.tmp && mv RELEASE_NOTES.tmp RELEASE_NOTES.md
+    git add RELEASE_NOTES.md
+    git commit --amend --no-edit
+  fi
+fi
+
+git push origin "$MERGE_BRANCH"
+
+# ── Create PR ──
 PR_RESPONSE=$(curl -s -X POST -H "$AUTH" -H "Content-Type: application/json" \
   "${API}/repos/${REPO}/pulls" \
   -d "{
     \"title\": \"Promote ${BRANCH} → ${BASE}\",
     \"body\": \"Automated promotion after CI pass on \`${BRANCH}\`.\",
-    \"head\": \"${BRANCH}\",
+    \"head\": \"${MERGE_BRANCH}\",
     \"base\": \"${BASE}\"
   }")
 
@@ -63,12 +140,16 @@ fi
 PR_URL=$(echo "$PR_RESPONSE" | jq -r '.html_url')
 echo "Created PR #${PR_NUMBER}: ${PR_URL}"
 
+# ── Auto-merge or request reviewer ──
 if [ "$MODE" = "auto" ]; then
   MERGE_RESULT=$(curl -s -X PUT -H "$AUTH" -H "Content-Type: application/json" \
     "${API}/repos/${REPO}/pulls/${PR_NUMBER}/merge" \
     -d '{"merge_method": "merge"}')
   if echo "$MERGE_RESULT" | jq -e '.merged' > /dev/null 2>&1; then
     echo "Auto-merged successfully"
+    # Clean up merge branch
+    curl -s -X DELETE -H "$AUTH" \
+      "${API}/repos/${REPO}/git/refs/heads/${MERGE_BRANCH}" > /dev/null 2>&1 || true
   else
     echo "Auto-merge queued or waiting for status checks"
   fi

--- a/scripts/woodpecker/sync-back.sh
+++ b/scripts/woodpecker/sync-back.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Sync RELEASE_NOTES.md from tagged release back to development and staging
+# Sync RELEASE_NOTES.md + VERSION from tagged release back to development and staging
 # Triggered by: tag event (v*)
 
 REPO="Peregrine-Technology-Systems/peregrine-penetrator-scanner"
@@ -42,18 +42,27 @@ for BRANCH in development staging; do
     continue
   fi
 
-  git fetch origin "$BRANCH" main
+  git fetch origin "$BRANCH"
   git checkout -b "$SYNC_BRANCH" "origin/${BRANCH}"
 
-  # Replace RELEASE_NOTES.md from main (authoritative source, not merge)
-  # This avoids merge=union duplicates and stale Unreleased entries entirely
-  git show origin/main:RELEASE_NOTES.md > RELEASE_NOTES.md
+  # Replace RELEASE_NOTES.md from tagged commit (not merge — prevents duplicate headings)
+  git checkout "${CI_COMMIT_SHA}" -- RELEASE_NOTES.md
 
-  # Re-insert ## Unreleased header (main doesn't have it after version-bump)
-  perl -i -pe 's/^(# Release Notes)$/$1\n\n## Unreleased/' RELEASE_NOTES.md
+  # Ensure exactly one ## Unreleased header exists (main may or may not have it)
+  if ! grep -q '^## Unreleased$' RELEASE_NOTES.md; then
+    perl -i -pe 'print "## Unreleased\n\n" if /^## v/ && !$done++' RELEASE_NOTES.md
+  fi
 
-  # Also sync VERSION file from main
-  git show origin/main:VERSION > VERSION
+  # Fallback: if still no Unreleased header, add after title
+  if ! grep -q '^## Unreleased$' RELEASE_NOTES.md; then
+    perl -i -pe 's/^(# Release Notes)$/$1\n\n## Unreleased/' RELEASE_NOTES.md
+  fi
+
+  # Dedup any duplicate headers (safety net)
+  awk '!seen[$0]++ || !/^## /' RELEASE_NOTES.md > RELEASE_NOTES.tmp && mv RELEASE_NOTES.tmp RELEASE_NOTES.md
+
+  # Sync VERSION file from tagged commit
+  git checkout "${CI_COMMIT_SHA}" -- VERSION
 
   git add RELEASE_NOTES.md VERSION
 


### PR DESCRIPTION
## Summary

- Replace direct GitHub API PR approach with local merge branch strategy in `promote.sh`
- promote.sh now merges locally (respects `.gitattributes merge=union` for RELEASE_NOTES.md), pushes a merge branch, and creates PRs from that
- Three guards prevent cascading promotions after sync-back (sync-back commit msg, release commit msg, in-flight PR detection)
- sync-back.sh improved: uses `CI_COMMIT_SHA` checkout instead of `git show origin/main`, multiple Unreleased header fallbacks, dedup safety net
- promote.yaml updated with `depth: 0` deep clone required for local merge operations
- Notification changed to failure-only (no success noise from promotions)

Copied from peregrine-penetrator-front-end (reference: front-end#420), adapted for Ruby stack (VERSION file instead of package.json).

Closes #578

## Test plan

- [ ] CI passes (syntax validation, RSpec, RuboCop)
- [ ] After merge to development, promotion to staging uses `merge/development-to-staging` branch
- [ ] RELEASE_NOTES.md conflicts auto-resolve via merge=union
- [ ] Sync-back after version-bump doesn't trigger cascading promotions
- [ ] staging→main PR created with manual review (not auto-merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)