### PR TITLE
fix: smoke tests verify scan completion status (#506)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix: smoke tests verify scan completion status and smoke-test checks, not just GCS artifact existence (#506)
+
 ## v0.13.2 — 2026-04-02
 
 - chore: promotion pipeline uses local merge branch — eliminates RELEASE_NOTES conflicts and cascading version bumps (#578)

--- a/scripts/woodpecker/smoke-test-cloud-function.sh
+++ b/scripts/woodpecker/smoke-test-cloud-function.sh
@@ -122,9 +122,63 @@ fi
 
 if [ -n "$JSON_FILES" ]; then
   echo "  PASS: JSON results found: ${JSON_FILES}"
+
+  TMPFILE=$(mktemp)
+  gsutil cp "$JSON_FILES" "$TMPFILE" 2>/dev/null
+
+  # Verify required keys exist
+  for key in schema_version metadata summary findings; do
+    if python3 -c "import json,sys; d=json.load(open('$TMPFILE')); assert '$key' in d" 2>/dev/null; then
+      echo "  PASS: JSON has '${key}' key"
+    else
+      echo "  FAIL: JSON missing '${key}' key"
+      ERRORS=$((ERRORS + 1))
+    fi
+  done
+
+  # Verify scan completed (not failed/crashed)
+  SCAN_STATUS=$(python3 -c "
+import json, sys
+d = json.load(open('$TMPFILE'))
+s = d.get('summary', {})
+status = d.get('status') or s.get('status', '')
+print(status)
+" 2>/dev/null || echo "")
+
+  if [ "$SCAN_STATUS" = "completed" ]; then
+    echo "  PASS: scan status=completed"
+  elif [ -n "$SCAN_STATUS" ]; then
+    echo "  FAIL: scan status=${SCAN_STATUS} (expected completed)"
+    ERRORS=$((ERRORS + 1))
+  else
+    echo "  WARN: no status field in results"
+  fi
+
+  # Verify smoke test flag and checks
+  python3 -c "
+import json, sys
+d = json.load(open('$TMPFILE'))
+s = d.get('summary', {})
+if s.get('smoke_test'):
+    checks = s.get('checks', {})
+    passed = s.get('passed', False)
+    print(f\"  Smoke test: {'PASSED' if passed else 'FAILED'}\")
+    for check, status in checks.items():
+        print(f\"    {check}: {status}\")
+    if not passed:
+        sys.exit(1)
+else:
+    print(f\"  Findings: {s.get('total_findings', 'unknown')}\")
+" 2>/dev/null
+  if [ $? -ne 0 ]; then
+    echo "  FAIL: smoke test checks did not pass"
+    ERRORS=$((ERRORS + 1))
+  fi
+
+  rm -f "$TMPFILE"
 else
-  echo "  WARN: No JSON results found for scan_uuid=${SCAN_UUID}"
-  echo "  (VM may not have written results yet, or path differs)"
+  echo "  FAIL: No JSON results found for scan_uuid=${SCAN_UUID}"
+  ERRORS=$((ERRORS + 1))
 fi
 
 # Summary

--- a/scripts/woodpecker/smoke-test.sh
+++ b/scripts/woodpecker/smoke-test.sh
@@ -71,6 +71,25 @@ if [ -n "$JSON_FILES" ]; then
     fi
   done
 
+  # Verify scan completed successfully (not failed/crashed)
+  SCAN_STATUS=$(python3 -c "
+import json, sys
+d = json.load(open('$TMPFILE'))
+s = d.get('summary', {})
+# Check both top-level status and summary.status
+status = d.get('status') or s.get('status', '')
+print(status)
+" 2>/dev/null || echo "")
+
+  if [ "$SCAN_STATUS" = "completed" ]; then
+    echo "  PASS: scan status=completed"
+  elif [ -n "$SCAN_STATUS" ]; then
+    echo "  FAIL: scan status=${SCAN_STATUS} (expected completed)"
+    ERRORS=$((ERRORS + 1))
+  else
+    echo "  WARN: no status field found in results"
+  fi
+
   # Check smoke test results in summary
   python3 -c "
 import json, sys
@@ -83,9 +102,15 @@ if s.get('smoke_test'):
     print(f\"  Smoke test: {'PASSED' if passed else 'FAILED'}\")
     for check, status in checks.items():
         print(f\"    {check}: {status}\")
+    if not passed:
+        sys.exit(1)
 else:
     print(f\"  Findings: {s.get('total_findings', 'unknown')}\")
-" 2>/dev/null || echo "  WARN: Could not parse JSON summary"
+" 2>/dev/null
+  if [ $? -ne 0 ]; then
+    echo "  FAIL: smoke test checks did not pass"
+    ERRORS=$((ERRORS + 1))
+  fi
 
   rm -f "$TMPFILE"
 else


### PR DESCRIPTION
## Summary

- Smoke tests now verify `status: completed` in scan_results.json — a crashed scan (ValidationFailed, status:failed) will fail the smoke test
- Both `smoke-test.sh` and `smoke-test-cloud-function.sh` verify smoke_test check results (passed/failed)
- Cloud function smoke test now downloads and validates results content (was only checking existence)
- Missing results upgraded from WARN to FAIL (no output = crashed scan)

Closes #506

## Test plan

- [ ] Verify smoke-test.sh parses scan_results.json status correctly
- [ ] Verify smoke-test-cloud-function.sh downloads and validates results
- [ ] Confirm CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)