### PR TITLE
fix: staging scans target correct URL (#595)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix: staging scans target correct URL (auxscan.app, not auxscan.stage) — fixes ZAP 600s timeout (#595)
+
 ## v0.13.4 — 2026-04-03
 
 - fix: Cloud Function health endpoints use HTTP method guard — GET always returns health, POST triggers scan (#575)

--- a/cloud/lib/scan-vm.sh
+++ b/cloud/lib/scan-vm.sh
@@ -16,8 +16,8 @@ IMAGE_TAG="${3:-${ENV}}"
 # Environment-specific configuration
 case "$ENV" in
   staging)
-    TARGET_NAME="AuxScan Staging"
-    TARGET_URLS='["https://auxscan.stage.data-estate.cloud"]'
+    TARGET_NAME="AuxScan Production"
+    TARGET_URLS='["https://auxscan.app.data-estate.cloud"]'
     VM_SCAN_NAME="pentest-scan-staging-$(date +%Y%m%d-%H%M%S)"
     SPOT_FLAG=""
     ;;

--- a/scripts/woodpecker/trigger-scan.sh
+++ b/scripts/woodpecker/trigger-scan.sh
@@ -20,19 +20,19 @@ VM_NAME="pentest-scan-${ENV}-$(date +%Y%m%d-%H%M%S)"
 case "$ENV" in
   development)
     TARGET_URLS='["https://auxscan.app.data-estate.cloud"]'
-    TARGET_NAME="auxscan-dev"
+    TARGET_NAME="AuxScan Production"
     IMAGE_TAG="development"
     SPOT_FLAG=""
     ;;
   staging)
-    TARGET_URLS='["https://auxscan.stage.data-estate.cloud"]'
-    TARGET_NAME="auxscan-staging"
+    TARGET_URLS='["https://auxscan.app.data-estate.cloud"]'
+    TARGET_NAME="AuxScan Production"
     IMAGE_TAG="staging"
     SPOT_FLAG=""
     ;;
   production)
     TARGET_URLS='["https://auxscan.app.data-estate.cloud"]'
-    TARGET_NAME="auxscan-production"
+    TARGET_NAME="AuxScan Production"
     IMAGE_TAG="production"
     SPOT_FLAG="--provisioning-model=SPOT --instance-termination-action=DELETE"
     ;;


### PR DESCRIPTION
## Summary

- Staging scans were targeting `https://auxscan.stage.data-estate.cloud` which doesn't exist — caused ZAP 600s timeout
- All environments now target `https://auxscan.app.data-estate.cloud` (the authorized test target)
- Target name normalized to "AuxScan Production" across all environments (was "auxscan-staging", "auxscan-dev", "auxscan-production")

Closes #595

## Test plan

- [ ] CI passes
- [ ] Staging deploy triggers scan against correct URL
- [ ] Slack alerts show "AuxScan Production" as target name

🤖 Generated with [Claude Code](https://claude.com/claude-code)