### PR TITLE
feat: GCS heartbeat every 30s for scan progress observability (#601)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,7 @@
 
 - fix: staging scans target correct URL (auxscan.app, not auxscan.stage) — fixes ZAP 600s timeout (#595)
 - fix: preflight reachability check aborts scan on unreachable target — 10s fail vs 600s per tool (#600)
+- feat: GCS heartbeat every 30s — scan progress observable via control/{uuid}/heartbeat.json (#601)
 
 ## v0.13.4 — 2026-04-03
 

--- a/app/services/control_plane_loop.rb
+++ b/app/services/control_plane_loop.rb
@@ -55,12 +55,27 @@ class ControlPlaneLoop
     Timeout.timeout(TICK_TIMEOUT) do
       progress = @mutex.synchronize { @progress.dup }
       @heartbeat.send_heartbeat(status: 'running', **progress)
+      write_gcs_heartbeat(progress)
       check_cancel
     end
   rescue Timeout::Error
     Penetrator.logger.warn("[ControlPlaneLoop] Tick timed out after #{TICK_TIMEOUT}s — skipping")
   rescue StandardError => e
     Penetrator.logger.warn("[ControlPlaneLoop] Tick error: #{e.message}")
+  end
+
+  def write_gcs_heartbeat(progress)
+    return if @gcs_bucket.to_s.empty?
+
+    payload = {
+      scan_uuid: @scan_uuid,
+      status: 'running',
+      timestamp: Time.current.iso8601,
+      **progress
+    }
+    StorageService.new.upload_json("control/#{@scan_uuid}/heartbeat.json", payload)
+  rescue StandardError => e
+    Penetrator.logger.warn("[ControlPlaneLoop] GCS heartbeat failed: #{e.message}")
   end
 
   def check_cancel

--- a/app/services/scan_orchestrator.rb
+++ b/app/services/scan_orchestrator.rb
@@ -54,8 +54,6 @@ class ScanOrchestrator
   private
 
   def start_control_plane
-    return nil unless HeartbeatSender.enabled?
-
     ControlPlaneLoop.new(
       scan_uuid: ENV.fetch('SCAN_UUID', scan.id),
       job_id: ENV.fetch('JOB_ID', nil),

--- a/spec/services/control_plane_loop_spec.rb
+++ b/spec/services/control_plane_loop_spec.rb
@@ -12,8 +12,9 @@ RSpec.describe ControlPlaneLoop do
   end
 
   before do
-    # Prevent actual HTTP calls
+    # Prevent actual HTTP calls and GCS writes
     allow_any_instance_of(HeartbeatSender).to receive(:send_heartbeat) # rubocop:disable RSpec/AnyInstance
+    allow_any_instance_of(StorageService).to receive(:upload_json) # rubocop:disable RSpec/AnyInstance
   end
 
   describe '#start / #stop' do
@@ -57,6 +58,43 @@ RSpec.describe ControlPlaneLoop do
       sender = instance_double(HeartbeatSender)
       allow(HeartbeatSender).to receive(:new).and_return(sender)
       expect(sender).to receive(:send_heartbeat).with(hash_including(status: 'running'))
+
+      loop_instance.send(:tick)
+    end
+
+    it 'writes GCS heartbeat on tick' do
+      storage = instance_double(StorageService)
+      allow(StorageService).to receive(:new).and_return(storage)
+      expect(storage).to receive(:upload_json).with(
+        'control/scan-123/heartbeat.json',
+        hash_including(scan_uuid: 'scan-123', status: 'running', timestamp: anything)
+      )
+
+      loop_instance.send(:tick)
+    end
+
+    it 'skips GCS heartbeat when no bucket configured' do
+      no_bucket_loop = described_class.new(
+        scan_uuid: 'scan-123',
+        job_id: 'job-456',
+        callback_url: 'https://reporter.example.com/callbacks/scan_complete',
+        gcs_bucket: '',
+        callback_secret: 'secret'
+      )
+
+      expect_any_instance_of(StorageService).not_to receive(:upload_json) # rubocop:disable RSpec/AnyInstance
+      no_bucket_loop.send(:tick)
+    end
+
+    it 'includes progress data in GCS heartbeat' do
+      loop_instance.update_progress(current_tool: 'zap', findings_count: 5)
+
+      storage = instance_double(StorageService)
+      allow(StorageService).to receive(:new).and_return(storage)
+      expect(storage).to receive(:upload_json).with(
+        anything,
+        hash_including(current_tool: 'zap', findings_count: 5)
+      )
 
       loop_instance.send(:tick)
     end


### PR DESCRIPTION
## Summary

- `ControlPlaneLoop` writes `control/{scan_uuid}/heartbeat.json` to GCS every 30s
- Payload: `{scan_uuid, status, timestamp, current_tool, progress_pct, findings_count}`
- Removed `CALLBACK_URL` gate — control plane always starts (GCS heartbeat works regardless)
- Enables heartbeat-based scavenging (#602)

Closes #601

## Test plan

- [x] 503 specs pass, 93.38% coverage
- [x] New specs: GCS heartbeat write, skip when no bucket, progress data included
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)