### PR TITLE
feat: heartbeat-aware scavenging + reduce soft max to 10m (#602)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,6 +5,7 @@
 - fix: staging scans target correct URL (auxscan.app, not auxscan.stage) — fixes ZAP 600s timeout (#595)
 - fix: preflight reachability check aborts scan on unreachable target — 10s fail vs 600s per tool (#600)
 - feat: GCS heartbeat every 30s — scan progress observable via control/{uuid}/heartbeat.json (#601)
+- feat: heartbeat-aware scavenging — kills stuck VMs with stale heartbeat, soft max reduced to 10m (#602)
 
 ## v0.13.4 — 2026-04-03
 

--- a/cloud/scheduler/main.py
+++ b/cloud/scheduler/main.py
@@ -17,7 +17,9 @@ MACHINE_TYPE = f'zones/{ZONE}/machineTypes/e2-standard-4'
 SERVICE_ACCOUNT = f'pentest-scanner@{PROJECT}.iam.gserviceaccount.com'
 IMAGE_FAMILY = 'ubuntu-2204-lts'
 IMAGE_PROJECT = 'ubuntu-os-cloud'
-MAX_AGE_MINUTES = int(os.environ.get('MAX_AGE_MINUTES', '30'))
+MAX_AGE_MINUTES = int(os.environ.get('MAX_AGE_MINUTES', '10'))
+HEARTBEAT_STALE_MINUTES = int(os.environ.get('HEARTBEAT_STALE_MINUTES', '5'))
+GCS_BUCKET = os.environ.get('GCS_BUCKET', f'{PROJECT}-pentest-reports')
 
 
 def _slack_notify(message):
@@ -78,6 +80,48 @@ def _check_vm_status(instance_name, zone_name):
     except Exception:
         return {'alive': False, 'containers': [], 'docker_ps': '',
                 'ssh_failed': True}
+
+
+def _check_heartbeat(scan_uuid):
+    """Check GCS for recent heartbeat from a scan VM.
+
+    Returns dict with:
+      - has_heartbeat: True if heartbeat.json exists
+      - stale_minutes: minutes since last heartbeat (None if no heartbeat)
+      - current_tool: tool name from heartbeat (None if unavailable)
+    """
+    if not scan_uuid:
+        return {'has_heartbeat': False, 'stale_minutes': None, 'current_tool': None}
+
+    from google.cloud import storage as gcs
+    try:
+        client = gcs.Client(project=PROJECT)
+        bucket = client.bucket(GCS_BUCKET)
+        blob = bucket.blob(f'control/{scan_uuid}/heartbeat.json')
+        if not blob.exists():
+            return {'has_heartbeat': False, 'stale_minutes': None, 'current_tool': None}
+
+        data = json.loads(blob.download_as_text())
+        ts = datetime.fromisoformat(data['timestamp'])
+        now = datetime.now(timezone.utc)
+        stale_minutes = (now - ts).total_seconds() / 60
+        return {
+            'has_heartbeat': True,
+            'stale_minutes': round(stale_minutes, 1),
+            'current_tool': data.get('current_tool'),
+        }
+    except Exception as e:
+        print(f'[vm-scavenger] Heartbeat check failed for {scan_uuid}: {e}')
+        return {'has_heartbeat': False, 'stale_minutes': None, 'current_tool': None}
+
+
+def _get_scan_uuid(instance):
+    """Extract SCAN_UUID from instance metadata."""
+    if instance.metadata and instance.metadata.items:
+        for item in instance.metadata.items:
+            if item.key == 'SCAN_UUID':
+                return item.value
+    return None
 
 
 def scavenge_vms(request):
@@ -151,15 +195,32 @@ def _scavenge_vms_inner():
                 continue
 
             status = _check_vm_status(instance.name, zone_name)
+            scan_uuid = _get_scan_uuid(instance)
+            heartbeat = _check_heartbeat(scan_uuid)
 
             if age_minutes <= hard_max_minutes and status['alive']:
-                skipped.append(
-                    f'{instance.name} ({int(age_minutes)}m, active)'
-                )
-                continue
+                # Container running — check heartbeat for actual progress
+                if heartbeat['has_heartbeat'] and heartbeat['stale_minutes'] is not None:
+                    if heartbeat['stale_minutes'] <= HEARTBEAT_STALE_MINUTES:
+                        skipped.append(
+                            f'{instance.name} ({int(age_minutes)}m, active, '
+                            f'heartbeat {heartbeat["stale_minutes"]}m ago, '
+                            f'tool: {heartbeat["current_tool"]})'
+                        )
+                        continue
+                    # Heartbeat stale — scan is stuck despite container running
+                else:
+                    # No heartbeat — legacy scan or pre-heartbeat code
+                    skipped.append(
+                        f'{instance.name} ({int(age_minutes)}m, active, no heartbeat)'
+                    )
+                    continue
 
             if age_minutes > hard_max_minutes:
                 reason = 'hard max exceeded (4h)'
+            elif heartbeat.get('has_heartbeat') and heartbeat.get('stale_minutes', 0) > HEARTBEAT_STALE_MINUTES:
+                reason = (f'heartbeat stale ({heartbeat["stale_minutes"]}m, '
+                          f'last tool: {heartbeat.get("current_tool", "unknown")})')
             elif status['ssh_failed']:
                 reason = 'SSH unreachable'
             else:

--- a/cloud/scheduler/requirements.txt
+++ b/cloud/scheduler/requirements.txt
@@ -1,2 +1,3 @@
 functions-framework==3.5.0
 google-cloud-compute==1.19.0
+google-cloud-storage==2.18.2

--- a/spec/cloud/scavenger_cloud_function_spec.rb
+++ b/spec/cloud/scavenger_cloud_function_spec.rb
@@ -122,6 +122,26 @@ RSpec.describe 'Cloud Function scavenger (main.py)' do # rubocop:disable RSpec/D
     end
   end
 
+  describe 'heartbeat-aware scavenging' do
+    it 'has a heartbeat check function' do
+      expect(script).to include('def _check_heartbeat(scan_uuid):')
+    end
+
+    it 'reads SCAN_UUID from instance metadata' do
+      expect(script).to include('def _get_scan_uuid(instance):')
+      expect(script).to include("item.key == 'SCAN_UUID'")
+    end
+
+    it 'checks GCS heartbeat staleness' do
+      expect(script).to include('HEARTBEAT_STALE_MINUTES')
+      expect(script).to include('heartbeat.json')
+    end
+
+    it 'uses 10-minute soft max by default' do
+      expect(script).to include("'10'")
+    end
+  end
+
   describe 'trigger function health guard' do
     it 'uses HTTP method as primary health check guard' do
       expect(script).to include("request.method == 'GET'")


### PR DESCRIPTION
## Summary

- Scavenger checks GCS `heartbeat.json` staleness before deciding keep/kill
- Fresh heartbeat (<5m) + container running → skip (actively working)
- Stale heartbeat (>5m) + container running → delete (stuck scan)
- `MAX_AGE_MINUTES` reduced from 30 to 10 (quick scans finish fast, orphans pile up)
- Slack notification includes heartbeat staleness and last tool name
- Added `google-cloud-storage==2.18.2` to requirements

Closes #602

## Test plan

- [x] 38 Python tests pass
- [x] 507 Ruby specs pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)