### PR TITLE
fix: abort scan on critical tool failure (#604)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,7 +7,7 @@
 - feat: GCS heartbeat every 30s — scan progress observable via control/{uuid}/heartbeat.json (#601)
 - feat: heartbeat-aware scavenging — kills stuck VMs with stale heartbeat, soft max reduced to 10m (#602)
 - feat: Slack notification on scan start with target, profile, scan ID (#603)
-- fix: abort scan on critical tool failure — first tool or connection errors terminate immediately (#604)
+- fix: abort scan on critical tool failure — first-tool or connection errors terminate scan immediately (#604)
 
 ## v0.13.4 — 2026-04-03
 

--- a/app/services/scan_orchestrator.rb
+++ b/app/services/scan_orchestrator.rb
@@ -180,15 +180,15 @@ class ScanOrchestrator
     save_findings(result[:findings]) if result[:findings]&.any?
     @tool_index = (@tool_index || 0) + 1
   rescue StandardError => e
-    if critical_failure?(e)
-      raise "Critical tool failure (#{tool_config.tool}): #{e.message}"
-    end
+    raise "Critical tool failure (#{tool_config.tool}): #{e.message}" if critical_failure?(e)
+
     Penetrator.logger.error("[ScanOrchestrator] Tool #{tool_config.tool} failed: #{e.message}")
   end
 
   def critical_failure?(error)
     # First tool in first phase failing = likely target issue
     return true if @phase_index&.zero? && (@tool_index || 0) <= 1
+
     # Connection-related errors are always critical
     error.message.match?(/unreachable|connection refused|name.*resolution|ECONNREFUSED|EHOSTUNREACH/i)
   end

--- a/spec/services/scan_orchestrator_spec.rb
+++ b/spec/services/scan_orchestrator_spec.rb
@@ -105,30 +105,10 @@ RSpec.describe ScanOrchestrator do
     end
 
     it 'continues when a non-critical tool fails (fail-forward)' do
-      passing_tool = instance_double(ScanProfile::ToolConfig, tool: 'ffuf', config: {})
-      phase1 = instance_double(ScanProfile::Phase, name: 'discovery', parallel: false)
-      allow(phase1).to receive(:tools).and_return([passing_tool])
-
-      failing_tool = instance_double(ScanProfile::ToolConfig, tool: 'zap', config: { mode: 'baseline' })
-      working_tool = instance_double(ScanProfile::ToolConfig, tool: 'nuclei', config: {})
-      phase2 = instance_double(ScanProfile::Phase, name: 'active', parallel: false)
-      allow(phase2).to receive(:tools).and_return([failing_tool, working_tool])
-
-      profile = instance_double(ScanProfile, name: 'standard', smoke: false, smoke_test: false, phases: [phase1, phase2])
-      allow(ScanProfile).to receive(:load).and_return(profile)
-
-      passing_scanner = instance_double(Scanners::FfufScanner)
-      failing_scanner = instance_double(Scanners::ZapScanner)
-      working_scanner = instance_double(Scanners::NucleiScanner)
-      allow(Scanners::FfufScanner).to receive(:new).and_return(passing_scanner)
-      allow(Scanners::ZapScanner).to receive(:new).and_return(failing_scanner)
-      allow(Scanners::NucleiScanner).to receive(:new).and_return(working_scanner)
-      allow(passing_scanner).to receive(:run).and_return({ success: true, findings: [] })
-      allow(failing_scanner).to receive(:run).and_raise(StandardError, 'ZAP crashed')
-      allow(working_scanner).to receive(:run).and_return({ success: true, findings: [] })
+      scanners = setup_two_phase_with_failing_tool('ZAP crashed')
 
       orchestrator.execute
-      expect(working_scanner).to have_received(:run)
+      expect(scanners[:working]).to have_received(:run)
     end
 
     it 'aborts scan when first tool in first phase fails (critical failure)' do
@@ -296,5 +276,31 @@ RSpec.describe ScanOrchestrator do
                                                       discovered_urls: ['https://example.com/admin']
                                                     })
     allow(zap_scanner).to receive(:run).and_return({ success: true, findings: [] })
+  end
+
+  def setup_two_phase_with_failing_tool(error_message)
+    passing_tool = instance_double(ScanProfile::ToolConfig, tool: 'ffuf', config: {})
+    phase1 = instance_double(ScanProfile::Phase, name: 'discovery', parallel: false)
+    allow(phase1).to receive(:tools).and_return([passing_tool])
+
+    failing_tool = instance_double(ScanProfile::ToolConfig, tool: 'zap', config: { mode: 'baseline' })
+    working_tool = instance_double(ScanProfile::ToolConfig, tool: 'nuclei', config: {})
+    phase2 = instance_double(ScanProfile::Phase, name: 'active', parallel: false)
+    allow(phase2).to receive(:tools).and_return([failing_tool, working_tool])
+
+    profile = instance_double(ScanProfile, name: 'standard', smoke: false, smoke_test: false, phases: [phase1, phase2])
+    allow(ScanProfile).to receive(:load).and_return(profile)
+
+    passing_scanner = instance_double(Scanners::FfufScanner)
+    failing_scanner = instance_double(Scanners::ZapScanner)
+    working_scanner = instance_double(Scanners::NucleiScanner)
+    allow(Scanners::FfufScanner).to receive(:new).and_return(passing_scanner)
+    allow(Scanners::ZapScanner).to receive(:new).and_return(failing_scanner)
+    allow(Scanners::NucleiScanner).to receive(:new).and_return(working_scanner)
+    allow(passing_scanner).to receive(:run).and_return({ success: true, findings: [] })
+    allow(failing_scanner).to receive(:run).and_raise(StandardError, error_message)
+    allow(working_scanner).to receive(:run).and_return({ success: true, findings: [] })
+
+    { passing: passing_scanner, failing: failing_scanner, working: working_scanner }
   end
 end


### PR DESCRIPTION
## Summary

- First tool in first phase failing → abort entire scan (likely target issue)
- Connection-related errors (ECONNREFUSED, unreachable, DNS) → abort in any phase
- Non-critical tool failures still fail-forward to next tool
- Defense-in-depth with preflight check (#600) — catches mid-scan target failures

Closes #604

## Test plan

- [x] 513 specs pass, 93.35% coverage
- [x] New specs: critical failure abort (first tool), connection error abort (any phase), non-critical continues

🤖 Generated with [Claude Code](https://claude.com/claude-code)