### PR TITLE
docs: update README and CLAUDE.md for v0.13.5 safety system (#620)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,11 +25,15 @@ Report generation, AI analysis, ticketing, and email notifications have been ext
 bin/scan (CLI entry point)
   ↓
 ScanOrchestrator
+├── mark_running → SlackNotifier.send_started (":rocket: Scan Started")
+├── preflight_check (HTTP HEAD each target URL, 10s timeout — fail fast on bad URLs)
+├── ControlPlaneLoop (30s heartbeat → GCS control/{uuid}/heartbeat.json + callback POST)
 ├── [smoke profile] → SmokeChecker (tools, GCS, secrets validation)
 ├── [scan profiles] →
 │   ├── Phase 1 Discovery: FfufScanner + NiktoScanner (parallel)
 │   ├── Phase 2 Active: ZapScanner (full DAST scan)
 │   └── Phase 3 Targeted: NucleiScanner + SqlmapScanner (parallel)
+│   (critical tool failure in phase 1 or connection errors → abort entire scan)
 │        ↓
 │   FindingNormalizer (SHA256 fingerprint dedup)
 │        ↓
@@ -76,7 +80,7 @@ CI runs on Woodpecker CI (self-hosted at d3ci42.peregrinetechsys.net). Pipeline 
 
 | Pipeline | Trigger | Steps |
 |----------|---------|-------|
-| `ci.yaml` | Push (all branches except main) | RSpec + RuboCop + check-release-notes (parallel) |
+| `ci.yaml` | Push (all branches except main) | RSpec + RuboCop + check-release-notes + test-cloud-functions (parallel) |
 | `build-base.yaml` | Push to development (Dockerfile.base changes) | Build + push scanner-base image |
 | `build.yaml` | Push to staging | Build baked scanner:staging image |
 | `deploy.yaml` | Push to staging/main | Staging: trigger scan VM. Main: tag staging as production |
@@ -90,6 +94,44 @@ CI runs on Woodpecker CI (self-hosted at d3ci42.peregrinetechsys.net). Pipeline 
 - **Staging**: Build baked `scanner:staging` image (freeze point, immutable)
 - **Production**: Re-tag `scanner:staging` as `scanner:production` (zero rebuild, identical bytes)
 - `VERSION` is a runtime env var, not baked into the image. Read via `Penetrator::VERSION`.
+
+## VM Safety System
+
+Scan VMs have 5 layers of protection against hung/orphaned instances:
+
+| Layer | Mechanism | Timeout | What it catches |
+|-------|-----------|---------|-----------------|
+| **Preflight** | HTTP HEAD target URLs | 10s | Bad URLs, DNS failures, unreachable hosts |
+| **Critical failure** | First tool or connection errors abort scan | Immediate | Target goes down mid-scan |
+| **GCS heartbeat** | `control/{uuid}/heartbeat.json` every 30s | 5m stale = stuck | Hung scans with live containers |
+| **Ruby timeout** | `Timeout.timeout(SCAN_TIMEOUT)` | 3600s | Scan exceeds global limit |
+| **Shell timeout** | `timeout --signal=TERM --kill-after=60` | 3600s | Ruby process hangs |
+| **Scavenger** | SSH + heartbeat check | 10m soft / 240m hard | All orphans |
+
+### Scavenger Decision Matrix
+- VM age <= 10m: skip (too young)
+- Container running + fresh heartbeat (<5m): skip (actively working)
+- Container running + stale heartbeat (>5m): delete (stuck)
+- Container running + no heartbeat: skip (legacy)
+- No container: delete
+- Age > 240m: delete unconditionally
+
+### Cloud Functions
+
+4 Cloud Functions in `cloud/scheduler/`:
+
+| Function | Entry point | Purpose |
+|----------|-------------|---------|
+| `vm-scavenger` | `scavenge_vms` | Delete orphaned scan VMs (Cloud Scheduler, every 5m) |
+| `trigger-scan-development` | `trigger_development` | Launch dev scan VM |
+| `trigger-scan-staging` | `trigger_staging` | Launch staging scan VM |
+| `trigger-scan-production` | `trigger_production` | Launch production scan VM (SPOT pricing) |
+
+**Health guard:** `request.method == 'GET'` returns health (primary). `request.path == '/health'` as secondary. GET requests never trigger scans.
+
+**Deploy:** `scripts/deploy-cloud-functions.sh` — deploys all 4 functions + verifies health endpoints return 200. Must be run manually after code changes.
+
+**Python tests:** `cd cloud/scheduler && python3 -m pytest test_main.py -v` (uses Flask test_request_context, not MagicMock). Run in CI via `test-cloud-functions` step in Docker.
 
 ## Security & Ethics
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,11 @@ flowchart TD
     B -->|smoke| D[SmokeChecker<br/>Infra validation]
     B -->|quick/standard/thorough| E[ScanOrchestrator]
 
-    E --> F[Discovery: ffuf + Nikto]
+    E --> N[Slack: Scan Started]
+    N --> P[Preflight Check<br/>HTTP HEAD targets, 10s timeout]
+    P -->|unreachable| X[Fail + self-terminate]
+    P -->|reachable| F[Discovery: ffuf + Nikto]
+    F -->|critical failure| X
     F --> G[Active: OWASP ZAP]
     G --> H[Targeted: Nuclei + sqlmap]
     H --> I[FindingNormalizer<br/>SHA256 dedup]
@@ -82,8 +86,11 @@ sequenceDiagram
 
     loop Every 30s
         S->>R: Heartbeat (progress, tool, findings)
+        S->>G: Write heartbeat.json (progress)
         S->>G: Check control.json for cancel
     end
+
+    Note over S: Scavenger checks heartbeat.json<br/>staleness every 5-10 min
 
     S->>G: Write scan_results.json
     S->>R: Callback (completed)
@@ -192,17 +199,27 @@ This project followed **stepwise refinement** — building a working monolith fi
 
 ## Reliability
 
+### 5-Layer VM Safety System
+
+| Layer | Mechanism | Timeout | Catches |
+|-------|-----------|---------|---------|
+| **Preflight** | HTTP HEAD each target URL | 10s | Bad URLs, DNS failures, unreachable hosts |
+| **Critical failure** | First tool or connection errors abort scan | Immediate | Target goes down mid-scan |
+| **GCS heartbeat** | `heartbeat.json` every 30s, scavenger checks staleness | 5m stale | Hung scans with live containers |
+| **Timeout** | Ruby `Timeout.timeout` + shell `timeout` wrapper | 3600s | Scans exceeding global limit |
+| **Scavenger** | SSH + heartbeat check, Cloud Scheduler every 5m | 10m soft / 240m hard | All orphaned VMs |
+
+### Additional Reliability
+
 | Mechanism | Prevents |
 |-----------|---------|
-| SCAN_TIMEOUT (default 3600s) | Hung scans |
 | Per-tool timeout (default 600s) | Individual tool hangs |
-| Heartbeat every 30s | Reporter detects dead scanners |
-| `last_tool_started_at` in heartbeat | Reporter detects hung tools |
+| Scan-start Slack notification | Silent scan launches |
 | `scan_started.json` marker | Detect started-but-never-completed scans |
 | `callback_pending.json` dead letter | Recover when callback fails |
-| VM self-terminate trap + scavenger | No orphan VMs |
 | Cancel via GCS `control.json` | Stop stale/runaway scans |
-| Deploy smoke test | Verify baked image works on ephemeral VM |
+| Deploy smoke test (validates status + results) | Broken baked images |
+| Health endpoint method guard (GET = health) | Health polls creating VMs |
 
 ### Deploy Verification
 
@@ -234,7 +251,7 @@ CI runs on [Woodpecker CI](https://d3ci42.peregrinetechsys.net) (self-hosted).
 
 | Pipeline | Trigger | Purpose |
 |----------|---------|---------|
-| `ci.yaml` | Push (not main) | RSpec + RuboCop + RELEASE_NOTES check |
+| `ci.yaml` | Push (not main) | RSpec + RuboCop + RELEASE_NOTES check + Python Cloud Function tests |
 | `build-base.yaml` | Dockerfile.base changes | Build scanner-base image |
 | `build.yaml` | Staging push | Build baked scanner:staging |
 | `deploy.yaml` | Staging/main push | Tag image, trigger scan VM |

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- docs: update README and CLAUDE.md for v0.13.5 VM safety system (#620)
+
 ## v0.13.5 — 2026-04-03
 
 - fix: staging scans target correct URL (auxscan.app, not auxscan.stage) — fixes ZAP 600s timeout (#595)


### PR DESCRIPTION
## Summary

- README scan pipeline diagram: adds preflight check + critical failure abort path
- README control plane diagram: adds GCS heartbeat write
- README reliability section: restructured as 5-layer VM safety system table
- README CI table: includes test-cloud-functions step
- CLAUDE.md architecture diagram: preflight, heartbeat, scan-start Slack
- CLAUDE.md new sections: VM Safety System (decision matrix), Cloud Functions (health guards, deploy script)

Closes #620

## Test plan

- [x] Docs-only change, no code
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)