### PR TITLE
fix: redirect docker output to log file — prevents GCE crash (#631)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix: redirect docker output to log file — prevents GCE script runner crash on long lines (#631)
+
 ## v0.14.0 — 2026-04-04
 
 - docs: update README and CLAUDE.md for v0.13.5 VM safety system (#620)

--- a/cloud/lib/vm-startup.sh
+++ b/cloud/lib/vm-startup.sh
@@ -149,6 +149,11 @@ case "$SCAN_MODE" in
       echo "Cloning repo (branch: development)..."
       git clone --depth 1 --branch development "${REPO_URL}" "${APP_DIR}"
 
+      # Redirect docker output to log file — GCE startup script runner crashes
+      # on long stdout lines (bufio.Scanner buffer overflow), killing the EXIT
+      # trap and orphaning the VM. See scanner#631.
+      SCAN_LOG="/tmp/scan.log"
+
       echo "Running ${SCAN_PROFILE} scan (timeout: ${SCAN_TIMEOUT}s)..."
       timeout --signal=TERM --kill-after=60 "${SCAN_TIMEOUT}" \
         docker run --rm \
@@ -158,7 +163,7 @@ case "$SCAN_MODE" in
           --name "pentest-scan-$(date +%Y%m%d-%H%M%S)" \
           "${BASE_IMAGE}" \
           bash -c "cd /app && bundle install --deployment --without development test --jobs 4 --quiet && bundle exec bin/scan" \
-          || SCAN_EXIT=$?
+          > "${SCAN_LOG}" 2>&1 || SCAN_EXIT=$?
     else
       # --- Image mode: pull baked image (staging or production) ---
       FULL_IMAGE="${REGISTRY}/scanner:${IMAGE_TAG}"
@@ -168,6 +173,8 @@ case "$SCAN_MODE" in
 
       docker pull "${FULL_IMAGE}"
 
+      SCAN_LOG="/tmp/scan.log"
+
       echo "Running ${SCAN_PROFILE} scan (timeout: ${SCAN_TIMEOUT}s)..."
       timeout --signal=TERM --kill-after=60 "${SCAN_TIMEOUT}" \
         docker run --rm \
@@ -176,8 +183,11 @@ case "$SCAN_MODE" in
           --name "pentest-scan-$(date +%Y%m%d-%H%M%S)" \
           "${FULL_IMAGE}" \
           bundle exec bin/scan \
-          || SCAN_EXIT=$?
+          > "${SCAN_LOG}" 2>&1 || SCAN_EXIT=$?
     fi
+
+    echo "--- Scan Log (last 20 lines) ---"
+    tail -20 "${SCAN_LOG}" 2>/dev/null || true
 
     if [ "$SCAN_EXIT" -eq 0 ]; then
       echo "Scan completed successfully"

--- a/cloud/scheduler/vm-startup.sh
+++ b/cloud/scheduler/vm-startup.sh
@@ -149,6 +149,11 @@ case "$SCAN_MODE" in
       echo "Cloning repo (branch: development)..."
       git clone --depth 1 --branch development "${REPO_URL}" "${APP_DIR}"
 
+      # Redirect docker output to log file — GCE startup script runner crashes
+      # on long stdout lines (bufio.Scanner buffer overflow), killing the EXIT
+      # trap and orphaning the VM. See scanner#631.
+      SCAN_LOG="/tmp/scan.log"
+
       echo "Running ${SCAN_PROFILE} scan (timeout: ${SCAN_TIMEOUT}s)..."
       timeout --signal=TERM --kill-after=60 "${SCAN_TIMEOUT}" \
         docker run --rm \
@@ -158,7 +163,7 @@ case "$SCAN_MODE" in
           --name "pentest-scan-$(date +%Y%m%d-%H%M%S)" \
           "${BASE_IMAGE}" \
           bash -c "cd /app && bundle install --deployment --without development test --jobs 4 --quiet && bundle exec bin/scan" \
-          || SCAN_EXIT=$?
+          > "${SCAN_LOG}" 2>&1 || SCAN_EXIT=$?
     else
       # --- Image mode: pull baked image (staging or production) ---
       FULL_IMAGE="${REGISTRY}/scanner:${IMAGE_TAG}"
@@ -168,6 +173,8 @@ case "$SCAN_MODE" in
 
       docker pull "${FULL_IMAGE}"
 
+      SCAN_LOG="/tmp/scan.log"
+
       echo "Running ${SCAN_PROFILE} scan (timeout: ${SCAN_TIMEOUT}s)..."
       timeout --signal=TERM --kill-after=60 "${SCAN_TIMEOUT}" \
         docker run --rm \
@@ -176,8 +183,11 @@ case "$SCAN_MODE" in
           --name "pentest-scan-$(date +%Y%m%d-%H%M%S)" \
           "${FULL_IMAGE}" \
           bundle exec bin/scan \
-          || SCAN_EXIT=$?
+          > "${SCAN_LOG}" 2>&1 || SCAN_EXIT=$?
     fi
+
+    echo "--- Scan Log (last 20 lines) ---"
+    tail -20 "${SCAN_LOG}" 2>/dev/null || true
 
     if [ "$SCAN_EXIT" -eq 0 ]; then
       echo "Scan completed successfully"


### PR DESCRIPTION
## Summary

GCE startup script runner crashes on long stdout lines (`bufio.Scanner: token too long`), sending SIGPIPE that kills the EXIT trap — `self_terminate` never fires, VM orphaned.

Fix: `docker run ... > /tmp/scan.log 2>&1`. GCE runner only sees `tail -20` summary. Full log preserved on VM.

Applied to both `cloud/scheduler/vm-startup.sh` and `cloud/lib/vm-startup.sh`.

Closes #631

## Test plan

- [x] 515 specs pass, 93.37% coverage
- [ ] CI passes
- [ ] Next production scan self-terminates cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)