### PR TITLE
fix: populate findings_count in tool_statuses (#541)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - feat: observable post-scan lifecycle — GCS status.json + Slack for upload/terminate phases (#630)
+- fix: populate findings_count per tool in tool_statuses JSON for reporter Appendix A (#541)
 
 ## v0.14.1 — 2026-04-04
 

--- a/app/services/scanner_base.rb
+++ b/app/services/scanner_base.rb
@@ -17,7 +17,8 @@ class ScannerBase
     result = execute
 
     if result[:success]
-      update_status('completed')
+      findings_count = Array(result[:findings]).length
+      update_status('completed', nil, findings_count:)
       logger.info("[#{tool_name}] Completed successfully")
     else
       update_status('failed', result[:error])
@@ -145,8 +146,8 @@ class ScannerBase
     )
   end
 
-  def update_status(status, error = nil)
-    entry = { status:, updated_at: Time.current.iso8601, error: }.compact
+  def update_status(status, error = nil, findings_count: nil)
+    entry = { status:, updated_at: Time.current.iso8601, error:, findings_count: }.compact
     scan.tool_statuses = (scan.tool_statuses || {}).merge(tool_name => entry)
     scan.save_changes
   end

--- a/spec/services/scanner_base_spec.rb
+++ b/spec/services/scanner_base_spec.rb
@@ -32,6 +32,20 @@ RSpec.describe ScannerBase do
     end
   end
 
+  let(:scanner_with_findings_class) do
+    Class.new(ScannerBase) do
+      def tool_name
+        'findings_scanner'
+      end
+
+      protected
+
+      def execute
+        { success: true, findings: [{ title: 'XSS' }, { title: 'SQLi' }, { title: 'CSRF' }] }
+      end
+    end
+  end
+
   let(:exception_scanner_class) do
     Class.new(ScannerBase) do
       def tool_name
@@ -54,6 +68,33 @@ RSpec.describe ScannerBase do
       scan.refresh
       statuses = scan.tool_statuses
       expect(statuses['test_scanner']['status']).to eq('completed')
+    end
+
+    it 'includes findings_count in completed tool status' do
+      scanner = scanner_with_findings_class.new(scan)
+      scanner.run
+
+      scan.refresh
+      statuses = scan.tool_statuses
+      expect(statuses['findings_scanner']['findings_count']).to eq(3)
+    end
+
+    it 'sets findings_count to 0 when no findings returned' do
+      scanner = test_scanner_class.new(scan)
+      scanner.run
+
+      scan.refresh
+      statuses = scan.tool_statuses
+      expect(statuses['test_scanner']['findings_count']).to eq(0)
+    end
+
+    it 'does not include findings_count in failed tool status' do
+      scanner = failing_scanner_class.new(scan)
+      scanner.run
+
+      scan.refresh
+      statuses = scan.tool_statuses
+      expect(statuses['failing_scanner']).not_to have_key('findings_count')
     end
 
     it 'returns the execute result on success' do


### PR DESCRIPTION
## Summary

- Adds `findings_count` to each tool's status entry in the `tool_statuses` JSON when a scanner completes successfully
- The reporter expects this field for the Appendix A per-tool findings table; previously it showed 0
- Includes 3 new RSpec tests covering: findings present, zero findings, and no count on failure

## Test plan

- [x] New tests pass: `bundle exec rspec spec/services/scanner_base_spec.rb`
- [x] Full suite passes: 522 examples, 0 failures
- [x] Coverage: 93.38% (above 90% minimum)
- [x] RuboCop: no offenses
- [ ] CI passes on this PR

Closes #541

🤖 Generated with [Claude Code](https://claude.com/claude-code)