### PR TITLE
fix: promote pipeline stuck running (#654)

### DIFF
--- a/.woodpecker/promote.yaml
+++ b/.woodpecker/promote.yaml
@@ -33,5 +33,5 @@ steps:
     commands:
       - scripts/woodpecker/notify-status.sh
     when:
-      - status: [failure]
+      - status: [success, failure]
     depends_on: [promote]

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- fix: promote pipeline stuck running — notify-status must run on success too for Woodpecker to finalize workflow (#654)
 - fix: comprehensive scan cost tracking — use SCAN_UUID from trigger as scan ID, track NVD API calls, GCS uploads (results + heartbeats + markers + dead letters), and BigQuery streaming insert bytes (#651)
 - fix: VM self-termination hardening — timeout on GCS upload, fallback shutdown on gcloud delete failure (#650)
 - fix: Slack notification sequence — tag message is informational gray, not gold celebration (#367)


### PR DESCRIPTION
## Summary

- Promote workflow's `notify-status` step only ran on `status: [failure]`. When promote succeeded, the step was skipped and Woodpecker's state machine never finalized the workflow — pipeline stayed "running" until killed by the stale pipeline detector.
- Changed to `status: [success, failure]` so the step always executes.

## Test plan

- [x] Verify promote.yaml change
- [ ] CI passes
- [ ] After merge, observe next promote pipeline completes cleanly

Closes #654

🤖 Generated with [Claude Code](https://claude.com/claude-code)