### PR TITLE
fix: empty SCAN_UUID breaks GCS control paths (#659)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- fix: empty SCAN_UUID breaks GCS control paths — fall back to generated UUID instead of empty string (#659)
 - fix: promote pipeline stuck running — notify-status must run on success too for Woodpecker to finalize workflow (#654)
 - fix: comprehensive scan cost tracking — use SCAN_UUID from trigger as scan ID, track NVD API calls, GCS uploads (results + heartbeats + markers + dead letters), and BigQuery streaming insert bytes (#651)
 - fix: VM self-termination hardening — timeout on GCS upload, fallback shutdown on gcloud delete failure (#650)

--- a/app/services/scan_orchestrator.rb
+++ b/app/services/scan_orchestrator.rb
@@ -64,7 +64,7 @@ class ScanOrchestrator
 
   def start_control_plane
     ControlPlaneLoop.new(
-      scan_uuid: ENV.fetch('SCAN_UUID', scan.id),
+      scan_uuid: ENV.fetch('SCAN_UUID', '').then { |v| v.present? ? v : scan.id },
       job_id: ENV.fetch('JOB_ID', nil),
       callback_url: ENV.fetch('CALLBACK_URL', ''),
       gcs_bucket: ENV.fetch('GCS_BUCKET', ''),
@@ -124,7 +124,7 @@ class ScanOrchestrator
   end
 
   def write_started_marker
-    scan_uuid = ENV.fetch('SCAN_UUID', scan.id)
+    scan_uuid = ENV.fetch('SCAN_UUID', '').then { |v| v.present? ? v : scan.id }
     marker = {
       scan_uuid:,
       job_id: ENV.fetch('JOB_ID', nil),

--- a/lib/models/scan.rb
+++ b/lib/models/scan.rb
@@ -9,7 +9,8 @@ class Scan < Sequel::Model
   one_to_many :findings
 
   def before_create
-    self.id ||= ENV.fetch('SCAN_UUID', nil) || SecureRandom.uuid
+    env_uuid = ENV.fetch('SCAN_UUID', nil)
+    self.id ||= (env_uuid.present? ? env_uuid : nil) || SecureRandom.uuid
     super
   end
 

--- a/spec/models/scan_spec.rb
+++ b/spec/models/scan_spec.rb
@@ -41,6 +41,13 @@ RSpec.describe Scan do
       expect(scan.id).to eq(trigger_uuid)
     end
 
+    it 'falls back to generated UUID when SCAN_UUID is empty string' do
+      stub_const('ENV', ENV.to_h.merge('SCAN_UUID' => ''))
+      scan = create(:scan)
+      expect(scan.id).to match(/\A[0-9a-f-]{36}\z/)
+      expect(scan.id).not_to be_empty
+    end
+
     it 'does not override an explicitly provided ID' do
       explicit_id = 'explicit-0000-1111-2222-333344445555'
       scan = create(:scan, id: explicit_id)


### PR DESCRIPTION
## Summary

- `ENV.fetch('SCAN_UUID', fallback)` returns `""` when the key exists but is empty — bypasses fallback
- Caused heartbeats to write to `control//heartbeat.json` (empty UUID path)
- Scan IDs could be empty strings, breaking reporter cost lookups
- Fix: all SCAN_UUID reads now check `.present?` before using the value

## Test plan

- [x] New test: empty SCAN_UUID falls back to generated UUID
- [x] Existing tests pass (28 examples, 0 failures)
- [x] RuboCop clean

Closes #659

🤖 Generated with [Claude Code](https://claude.com/claude-code)