### PR TITLE
refactor: reduce redundant object instantiation and code duplication (#653)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,7 @@
 
 - fix: empty SCAN_UUID breaks GCS control paths — fall back to generated UUID instead of empty string (#659)
 - fix: promote pipeline stuck running — notify-status must run on success too for Woodpecker to finalize workflow (#654)
+- refactor: reduce redundant object instantiation and code duplication across services (#653)
 - fix: comprehensive scan cost tracking — use SCAN_UUID from trigger as scan ID, track NVD API calls, GCS uploads (results + heartbeats + markers + dead letters), and BigQuery streaming insert bytes (#651)
 - fix: VM self-termination hardening — timeout on GCS upload, fallback shutdown on gcloud delete failure (#650)
 - fix: Slack notification sequence — tag message is informational gray, not gold celebration (#367)

--- a/app/services/big_query_logger.rb
+++ b/app/services/big_query_logger.rb
@@ -54,20 +54,28 @@ class BigQueryLogger
     @cost_logger = cost_logger
   end
 
-  # New JSON-first interface: load from the versioned scan results envelope
   def log_from_json(scan_results)
-    findings_count = log_findings_from_json(scan_results)
-    log_metadata_from_json(scan_results)
+    schema_version = flex(scan_results, 'schema_version')
+    metadata = flex(scan_results, 'metadata') || {}
+    summary = flex(scan_results, 'summary') || {}
+    findings = flex(scan_results, 'findings') || []
+
+    findings_count = log_findings(findings, metadata, schema_version)
+    log_metadata(metadata, summary, schema_version)
     findings_count
   rescue StandardError => e
     Penetrator.logger.error("[BigQueryLogger] Failed: #{e.message}")
     0
   end
 
-  # Legacy interface: load from ActiveRecord scan object (backward compatible)
-  def log_findings(scan)
+  # Legacy interface: load from Sequel scan object
+  def log_findings_from_scan(scan)
     findings = scan.findings_dataset.non_duplicate
-    rows = findings.map { |f| build_row_from_ar(f, scan) }
+    schema_version = ScanResultsExporter::SCHEMA_VERSION
+    metadata = { scan_id: scan.id, target_urls: scan.target.url_list,
+                 started_at: scan.started_at || scan.created_at, profile: scan.profile }
+
+    rows = findings.map { |f| build_finding_row(normalize_ar_finding(f), metadata, schema_version) }
     return 0 if rows.empty?
 
     insert_rows(ensure_findings_table, rows, 'findings')
@@ -80,106 +88,84 @@ class BigQueryLogger
     ENV['GOOGLE_CLOUD_PROJECT'].present?
   end
 
-  # Keep legacy alias for backward compatibility
   def table_name
     findings_table_name
   end
 
   private
 
-  def log_findings_from_json(scan_results)
-    schema_version = scan_results['schema_version'] || scan_results[:schema_version]
-    metadata = scan_results['metadata'] || scan_results[:metadata] || {}
-    findings = scan_results['findings'] || scan_results[:findings] || []
+  # Flexible key access — handles both string and symbol keys
+  def flex(hash, key)
+    hash[key] || hash[key.to_sym]
+  end
+
+  def log_findings(findings, metadata, schema_version)
     return 0 if findings.empty?
 
-    rows = findings.map { |f| build_row_from_json(f, metadata, schema_version) }
+    rows = findings.map { |f| build_finding_row(f, metadata, schema_version) }
     insert_rows(ensure_findings_table, rows, 'findings')
   end
 
-  def log_metadata_from_json(scan_results)
-    schema_version = scan_results['schema_version'] || scan_results[:schema_version]
-    metadata = scan_results['metadata'] || scan_results[:metadata] || {}
-    summary = scan_results['summary'] || scan_results[:summary] || {}
-
+  def log_metadata(metadata, summary, schema_version)
     row = {
-      scan_id: metadata['scan_id'] || metadata[:scan_id],
-      target_name: metadata['target_name'] || metadata[:target_name],
-      profile: metadata['profile'] || metadata[:profile],
-      duration_seconds: summary['duration_seconds'] || summary[:duration_seconds],
-      tool_statuses: (metadata['tool_statuses'] || metadata[:tool_statuses] || {}).to_json,
+      scan_id: flex(metadata, 'scan_id'),
+      target_name: flex(metadata, 'target_name'),
+      profile: flex(metadata, 'profile'),
+      duration_seconds: flex(summary, 'duration_seconds'),
+      tool_statuses: (flex(metadata, 'tool_statuses') || {}).to_json,
       schema_version:,
-      scan_date: metadata['started_at'] || metadata[:started_at] || Time.now.iso8601,
-      total_findings: summary['total_findings'] || summary[:total_findings],
-      by_severity: (summary['by_severity'] || summary[:by_severity] || {}).to_json
+      scan_date: flex(metadata, 'started_at') || Time.now.iso8601,
+      total_findings: flex(summary, 'total_findings'),
+      by_severity: (flex(summary, 'by_severity') || {}).to_json
     }
 
     insert_rows(ensure_metadata_table, [row], 'metadata')
   end
 
-  def build_row_from_json(finding, metadata, schema_version)
-    evidence = finding['evidence'] || finding[:evidence]
+  def build_finding_row(finding, metadata, schema_version)
+    evidence = flex(finding, 'evidence')
     {
-      fingerprint: finding['fingerprint'] || finding[:id] || SecureRandom.hex(32),
-      site: Array(metadata['target_urls'] || metadata[:target_urls]).first,
-      scan_id: metadata['scan_id'] || metadata[:scan_id],
-      scan_date: metadata['started_at'] || metadata[:started_at] || Time.now.iso8601,
-      profile: metadata['profile'] || metadata[:profile],
+      fingerprint: flex(finding, 'fingerprint') || flex(finding, 'id') || SecureRandom.hex(32),
+      site: Array(flex(metadata, 'target_urls')).first,
+      scan_id: flex(metadata, 'scan_id'),
+      scan_date: flex(metadata, 'started_at') || Time.now.iso8601,
+      profile: flex(metadata, 'profile'),
       schema_version:,
-      severity: finding['severity'] || finding[:severity],
-      title: finding['title'] || finding[:title],
-      tool: finding['source_tool'] || finding[:source_tool],
-      cwe_id: finding['cwe_id'] || finding[:cwe_id],
-      cve_id: finding['cve_id'] || finding[:cve_id],
-      url: finding['url'] || finding[:url],
-      parameter: finding['parameter'] || finding[:parameter],
-      cvss_score: finding['cvss_score'] || finding[:cvss_score],
-      cvss_vector: finding['cvss_vector'] || finding[:cvss_vector],
-      epss_score: finding['epss_score'] || finding[:epss_score],
-      kev_known_exploited: finding['kev_known_exploited'] || finding[:kev_known_exploited],
+      severity: flex(finding, 'severity'),
+      title: flex(finding, 'title'),
+      tool: flex(finding, 'source_tool'),
+      cwe_id: flex(finding, 'cwe_id'),
+      cve_id: flex(finding, 'cve_id'),
+      url: flex(finding, 'url'),
+      parameter: flex(finding, 'parameter'),
+      cvss_score: flex(finding, 'cvss_score'),
+      cvss_vector: flex(finding, 'cvss_vector'),
+      epss_score: flex(finding, 'epss_score'),
+      kev_known_exploited: flex(finding, 'kev_known_exploited'),
       evidence: evidence.is_a?(Hash) ? evidence.to_json : evidence&.to_s,
-      ticket_system: ticket_from_evidence(evidence, 'ticket_system'),
-      ticket_ref: ticket_from_evidence(evidence, 'ticket_ref'),
-      ticket_pushed_at: ticket_from_evidence(evidence, 'ticket_pushed_at'),
-      ticket_status: ticket_from_evidence(evidence, 'ticket_ref') ? 'open' : nil
+      ticket_system: ticket_from(evidence, 'ticket_system'),
+      ticket_ref: ticket_from(evidence, 'ticket_ref'),
+      ticket_pushed_at: ticket_from(evidence, 'ticket_pushed_at'),
+      ticket_status: ticket_from(evidence, 'ticket_ref') ? 'open' : nil
     }
   end
 
-  # Legacy: build row from ActiveRecord objects
-  def build_row_from_ar(finding, scan)
+  def normalize_ar_finding(finding)
     {
-      fingerprint: finding.fingerprint,
-      site: scan.target.url_list.first,
-      scan_id: scan.id,
-      scan_date: scan.started_at || scan.created_at,
-      profile: scan.profile,
-      schema_version: ScanResultsExporter::SCHEMA_VERSION,
-      severity: finding.severity,
-      title: finding.title,
-      tool: finding.source_tool,
-      cwe_id: finding.cwe_id,
-      cve_id: finding.cve_id,
-      url: finding.url,
-      parameter: finding.parameter,
-      cvss_score: finding.cvss_score,
-      cvss_vector: finding.cvss_vector,
-      epss_score: finding.epss_score,
-      kev_known_exploited: finding.kev_known_exploited,
-      evidence: finding.evidence.is_a?(Hash) ? finding.evidence.to_json : finding.evidence&.to_s,
-      ticket_system: ticket_field(finding, 'ticket_system'),
-      ticket_ref: ticket_field(finding, 'ticket_ref'),
-      ticket_pushed_at: ticket_field(finding, 'ticket_pushed_at'),
-      ticket_status: ticket_field(finding, 'ticket_ref') ? 'open' : nil
+      fingerprint: finding.fingerprint, id: finding.id,
+      severity: finding.severity, title: finding.title,
+      source_tool: finding.source_tool, cwe_id: finding.cwe_id,
+      cve_id: finding.cve_id, url: finding.url, parameter: finding.parameter,
+      cvss_score: finding.cvss_score, cvss_vector: finding.cvss_vector,
+      epss_score: finding.epss_score, kev_known_exploited: finding.kev_known_exploited,
+      evidence: finding.evidence
     }
   end
 
-  def ticket_from_evidence(evidence, key)
-    evidence.is_a?(Hash) ? (evidence[key] || evidence[key.to_sym]) : nil
-  end
+  def ticket_from(evidence, key)
+    return nil unless evidence.is_a?(Hash)
 
-  def ticket_field(finding, key)
-    ev = finding.evidence
-    ev.is_a?(Hash) ? ev[key] : nil
+    evidence[key] || evidence[key.to_sym]
   end
 
   def insert_rows(table, rows, label)

--- a/app/services/data_retention_purger.rb
+++ b/app/services/data_retention_purger.rb
@@ -59,10 +59,8 @@ class DataRetentionPurger
   end
 
   def purge_table(dataset_id, table_name, date_column)
-    dataset = @client.dataset(dataset_id)
-    return { success: true, rows_deleted: 0 } unless dataset&.table(table_name)
+    return { success: true, rows_deleted: 0 } unless table_exists?(dataset_id, table_name)
 
-    cutoff_str = @cutoff.strftime('%Y-%m-%d %H:%M:%S UTC')
     sql = "DELETE FROM `#{dataset_id}.#{table_name}` WHERE #{date_column} < '#{cutoff_str}'"
     result = @client.query(sql)
     rows_deleted = result.total || 0
@@ -75,16 +73,23 @@ class DataRetentionPurger
   end
 
   def count_purgeable(dataset_id, table_name, date_column)
-    dataset = @client.dataset(dataset_id)
-    return 0 unless dataset&.table(table_name)
+    return 0 unless table_exists?(dataset_id, table_name)
 
-    cutoff_str = @cutoff.strftime('%Y-%m-%d %H:%M:%S UTC')
     sql = "SELECT COUNT(*) AS cnt FROM `#{dataset_id}.#{table_name}` WHERE #{date_column} < '#{cutoff_str}'"
     result = @client.query(sql)
     result.first[:cnt]
   rescue StandardError => e
     Penetrator.logger.error("[DataRetentionPurger] Preview failed for #{table_name}: #{e.message}")
     -1
+  end
+
+  def table_exists?(dataset_id, table_name)
+    dataset = @client.dataset(dataset_id)
+    dataset&.table(table_name) ? true : false
+  end
+
+  def cutoff_str
+    @cutoff.strftime('%Y-%m-%d %H:%M:%S UTC')
   end
 
   def log_purge_event(results)

--- a/app/services/notifiers/slack_notifier.rb
+++ b/app/services/notifiers/slack_notifier.rb
@@ -5,14 +5,7 @@ module Notifiers
     end
 
     def send_notification
-      url = ENV.fetch('SLACK_WEBHOOK_URL', nil)
-      payload = build_payload
-
-      response = Faraday.post(url) do |req|
-        req.headers['Content-Type'] = 'application/json'
-        req.body = payload.to_json
-      end
-
+      response = self.class.post_webhook(build_payload)
       Penetrator.logger.info("[NotificationService] Webhook sent: #{response.status}")
     end
 
@@ -47,13 +40,17 @@ module Notifiers
         ]
       }
 
+      post_webhook(payload)
+    rescue StandardError => e
+      Penetrator.logger.error("[SlackNotifier] Failed to send start notification: #{e.message}")
+    end
+
+    def self.post_webhook(payload)
       url = ENV.fetch('SLACK_WEBHOOK_URL', nil)
       Faraday.post(url) do |req|
         req.headers['Content-Type'] = 'application/json'
         req.body = payload.to_json
       end
-    rescue StandardError => e
-      Penetrator.logger.error("[SlackNotifier] Failed to send start notification: #{e.message}")
     end
 
     private

--- a/app/services/result_parsers/nuclei_parser.rb
+++ b/app/services/result_parsers/nuclei_parser.rb
@@ -48,22 +48,22 @@ module ResultParsers
     private
 
     def extract_cwe(data)
-      cwe = data.dig('info', 'classification', 'cwe-id')
-      return nil unless cwe
-
-      cwe.is_a?(Array) ? cwe.first : cwe.to_s
-    end
-
-    def extract_float(data, key)
-      val = data.dig('info', 'classification', key)
-      val&.to_f
+      extract_classification(data, 'cwe-id')
     end
 
     def extract_cve(data)
-      cve = data.dig('info', 'classification', 'cve-id')
-      return nil unless cve
+      extract_classification(data, 'cve-id')
+    end
 
-      cve.is_a?(Array) ? cve.first : cve.to_s
+    def extract_classification(data, key)
+      val = data.dig('info', 'classification', key)
+      return nil unless val
+
+      val.is_a?(Array) ? val.first : val.to_s
+    end
+
+    def extract_float(data, key)
+      data.dig('info', 'classification', key)&.to_f
     end
   end
 end

--- a/app/services/storage_service.rb
+++ b/app/services/storage_service.rb
@@ -35,9 +35,7 @@ class StorageService
   end
 
   def upload_to_gcs(local_path, remote_path, content_type)
-    require 'google/cloud/storage'
-    storage = Google::Cloud::Storage.new
-    bucket = storage.bucket(@bucket_name)
+    bucket = gcs_bucket
     unless bucket
       Penetrator.logger.warn("[StorageService] GCS bucket '#{@bucket_name}' inaccessible — falling back to local storage")
       return upload_local(local_path, remote_path)
@@ -56,15 +54,19 @@ class StorageService
   end
 
   def gcs_signed_url(remote_path, expires_in)
-    require 'google/cloud/storage'
-    storage = Google::Cloud::Storage.new
-    bucket = storage.bucket(@bucket_name)
+    bucket = gcs_bucket
     unless bucket
       Penetrator.logger.warn("[StorageService] GCS bucket '#{@bucket_name}' inaccessible — falling back to local URL")
       return "file://#{local_storage_path(remote_path)}"
     end
     file = bucket.file(remote_path)
     file.signed_url(expires: expires_in.to_i, method: 'GET')
+  end
+
+  def gcs_bucket
+    require 'google/cloud/storage'
+    @gcs_client ||= Google::Cloud::Storage.new
+    @gcs_client.bucket(@bucket_name)
   end
 
   def local_storage_path(remote_path)

--- a/spec/services/big_query_logger_spec.rb
+++ b/spec/services/big_query_logger_spec.rb
@@ -202,7 +202,7 @@ RSpec.describe BigQueryLogger do
         bq_mocks[:response]
       end
 
-      described_class.new.log_findings(scan)
+      described_class.new.log_findings_from_scan(scan)
     end
 
     it 'excludes duplicate findings' do
@@ -219,11 +219,11 @@ RSpec.describe BigQueryLogger do
         bq_mocks[:response]
       end
 
-      described_class.new.log_findings(scan)
+      described_class.new.log_findings_from_scan(scan)
     end
 
     it 'returns the count of logged findings' do
-      expect(described_class.new.log_findings(scan)).to eq(1)
+      expect(described_class.new.log_findings_from_scan(scan)).to eq(1)
     end
   end
 


### PR DESCRIPTION
## Summary

- **StorageService**: cache GCS client as `@gcs_client` — was creating new client per call
- **BigQueryLogger**: `flex()` helper for string/symbol key access, unified row building via `normalize_ar_finding()`, metadata extracted once in `log_from_json`
- **SlackNotifier**: extracted `post_webhook()` class method shared by instance and class methods
- **DataRetentionPurger**: extracted `table_exists?()` and `cutoff_str()` helpers
- **NucleiParser**: extracted `extract_classification()` for CWE/CVE dedup

Net: -9 lines (103 added, 112 removed)

## Test plan

- [x] 49 specs pass across all changed services
- [x] RuboCop clean
- [ ] CI pipeline

Closes #653

🤖 Generated with [Claude Code](https://claude.com/claude-code)