### PR TITLE
fix: heartbeat stops updating during long Nuclei scans (#661)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix: heartbeat stops updating during long Nuclei scans — cache StorageService, isolate tick operations with independent timeouts (#661)
+
 ## v0.15.2 — 2026-04-05
 
 - feat: tool chain in GCS export and callback — planned tools, per-tool timing, exit codes, findings count; schema v1.2 (#663)

--- a/app/services/control_plane_loop.rb
+++ b/app/services/control_plane_loop.rb
@@ -11,6 +11,7 @@ class ControlPlaneLoop
     )
     @gcs_bucket = gcs_bucket
     @cost_logger = cost_logger
+    @storage = StorageService.new if gcs_bucket.to_s.present?
     @mutex = Mutex.new
     @cancelled = false
     @running = false
@@ -55,20 +56,22 @@ class ControlPlaneLoop
   end
 
   def tick
-    Timeout.timeout(TICK_TIMEOUT) do
-      progress = @mutex.synchronize { @progress.dup }
-      @heartbeat.send_heartbeat(status: 'running', **progress)
-      write_gcs_heartbeat(progress)
-      check_cancel
-    end
+    progress = @mutex.synchronize { @progress.dup }
+    safe_call('callback') { @heartbeat.send_heartbeat(status: 'running', **progress) }
+    safe_call('GCS heartbeat') { write_gcs_heartbeat(progress) }
+    safe_call('cancel check') { check_cancel }
+  end
+
+  def safe_call(label, &)
+    Timeout.timeout(TICK_TIMEOUT, &)
   rescue Timeout::Error
-    Penetrator.logger.warn("[ControlPlaneLoop] Tick timed out after #{TICK_TIMEOUT}s — skipping")
+    Penetrator.logger.warn("[ControlPlaneLoop] #{label} timed out after #{TICK_TIMEOUT}s — skipping")
   rescue StandardError => e
-    Penetrator.logger.warn("[ControlPlaneLoop] Tick error: #{e.message}")
+    Penetrator.logger.warn("[ControlPlaneLoop] #{label} error: #{e.message}")
   end
 
   def write_gcs_heartbeat(progress)
-    return if @gcs_bucket.to_s.empty?
+    return unless @storage
 
     payload = {
       scan_uuid: @scan_uuid,
@@ -77,19 +80,15 @@ class ControlPlaneLoop
       **progress
     }
     @cost_logger&.track_gcs_upload(payload.to_json.bytesize)
-    StorageService.new.upload_json("control/#{@scan_uuid}/heartbeat.json", payload)
-  rescue StandardError => e
-    Penetrator.logger.warn("[ControlPlaneLoop] GCS heartbeat failed: #{e.message}")
+    @storage.upload_json("control/#{@scan_uuid}/heartbeat.json", payload)
   end
 
   def check_cancel
     return unless ControlFlagReader.enabled?
 
-    if ControlFlagReader.new(gcs_bucket: @gcs_bucket, scan_uuid: @scan_uuid).cancelled?
-      @mutex.synchronize { @cancelled = true }
-      Penetrator.logger.info('[ControlPlaneLoop] Cancel signal detected')
-    end
-  rescue StandardError => e
-    Penetrator.logger.warn("[ControlPlaneLoop] Cancel check failed: #{e.message}")
+    return unless ControlFlagReader.new(gcs_bucket: @gcs_bucket, scan_uuid: @scan_uuid).cancelled?
+
+    @mutex.synchronize { @cancelled = true }
+    Penetrator.logger.info('[ControlPlaneLoop] Cancel signal detected')
   end
 end

--- a/spec/services/control_plane_loop_spec.rb
+++ b/spec/services/control_plane_loop_spec.rb
@@ -87,16 +87,23 @@ RSpec.describe ControlPlaneLoop do
     end
 
     it 'includes progress data in GCS heartbeat' do
-      loop_instance.update_progress(current_tool: 'zap', findings_count: 5)
-
       storage = instance_double(StorageService)
       allow(StorageService).to receive(:new).and_return(storage)
+      allow(storage).to receive(:upload_json)
+
+      instance = described_class.new(
+        scan_uuid: 'scan-123', job_id: 'job-456',
+        callback_url: 'https://reporter.example.com/callbacks/scan_complete?job_id=j1',
+        gcs_bucket: 'test-bucket', callback_secret: 'secret'
+      )
+      instance.update_progress(current_tool: 'zap', findings_count: 5)
+
       expect(storage).to receive(:upload_json).with(
         anything,
         hash_including(current_tool: 'zap', findings_count: 5)
       )
 
-      loop_instance.send(:tick)
+      instance.send(:tick)
     end
   end
 end


### PR DESCRIPTION
## Summary

- Cache `StorageService` in constructor — was creating new GCS client every 30s tick
- Split tick into independent `safe_call` blocks with their own 10s timeouts — a slow callback no longer blocks the GCS heartbeat write

Previously: single `Timeout.timeout(10)` wrapped callback + GCS + cancel check. If callback took 8s, GCS heartbeat only had 2s before timeout.

Now: each operation gets its own 10s window.

## Test plan

- [x] 9 specs pass
- [x] RuboCop clean
- [ ] CI pipeline

Closes #661

🤖 Generated with [Claude Code](https://claude.com/claude-code)