### PR TITLE
fix: pre-commit hook skips lint on spec files (#683)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -7,7 +7,7 @@ FAILED=0
 # DOCS-ONLY BYPASS: skip tests/coverage if only docs changed
 # ============================================================
 ALL_STAGED=$(git diff --cached --name-only --diff-filter=ACM)
-CODE_FILES=$(echo "$ALL_STAGED" | grep -E '\.(rb|rake|yml|yaml|erb|latex|sh|Gemfile)$' | grep -v 'spec/' || true)
+CODE_FILES=$(echo "$ALL_STAGED" | grep -E '\.(rb|rake|yml|yaml|erb|latex|sh|Gemfile)$' || true)
 DOCS_ONLY=false
 if [ -z "$CODE_FILES" ]; then
   DOCS_ONLY=true
@@ -17,7 +17,7 @@ fi
 # ============================================================
 # 1. RELEASE_NOTES.md must be updated if code files changed
 # ============================================================
-CODE_CHANGED=$(git diff --cached --name-only --diff-filter=ACM | grep -E '\.(rb|yml|yaml|rake|erb|latex)$' | grep -v 'spec/' || true)
+CODE_CHANGED=$(git diff --cached --name-only --diff-filter=ACM | grep -E '\.(rb|yml|yaml|rake|erb|latex)$' || true)
 NOTES_CHANGED=$(git diff --cached --name-only | grep 'RELEASE_NOTES.md' || true)
 
 if [ -n "$CODE_CHANGED" ] && [ -z "$NOTES_CHANGED" ]; then


### PR DESCRIPTION
Removed `grep -v 'spec/'` from code file detection — spec files are code, not docs.