### PR TITLE
fix: revert promote depends_on deploy — blocks dev promotion (#691)

### DIFF
--- a/.woodpecker/promote.yaml
+++ b/.woodpecker/promote.yaml
@@ -5,7 +5,6 @@ when:
 
 depends_on:
   - ci
-  - deploy
 
 labels:
   platform: linux

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - fix: VM startup failure observability — Cloud Function writes vm-created marker to GCS, EXIT trap sends failure callback to orchestrator (#711)
+- fix: revert promote depends_on deploy — deploy only runs on staging, blocking dev→staging promotion (#691)
 - fix: heartbeat stops updating during long Nuclei scans — chunked stdout reading yields GIL to heartbeat thread (#697)
 - fix: sync-back PRs no longer block unrelated promotions — guard scoped to target base branch (#698)
 - fix: make callback_url a required parameter from trigger call — reject with 400 if missing (#695)


### PR DESCRIPTION
## Summary

- Reverts `depends_on: [ci, deploy]` back to `depends_on: [ci]` in promote.yaml
- `deploy.yaml` only triggers on staging pushes — having it as a dependency blocks dev→staging promotion entirely since Woodpecker skips workflows when a dependency doesn't exist
- The original #691 fix was for repos that deploy on development (orchestrator); this repo doesn't

Discovered while promoting #711 — CI passed but promote never triggered.

## Test plan

- [ ] CI passes
- [ ] Promote pipeline triggers after CI on development merge
- [ ] dev→staging promotion PR created and auto-merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)