### PR TITLE
fix: SPOT pricing opt-in — defaults to on-demand for reliability (#719)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- fix: scan VMs preempted immediately — SPOT pricing now opt-in, defaults to on-demand for reliability (#719)
 - fix: VM startup failure observability — Cloud Function writes vm-created marker to GCS, EXIT trap sends failure callback to orchestrator (#711)
 - fix: revert promote depends_on deploy — deploy only runs on staging, blocking dev→staging promotion (#691)
 - fix: heartbeat stops updating during long Nuclei scans — chunked stdout reading yields GIL to heartbeat thread (#697)

--- a/cloud/scheduler/main.py
+++ b/cloud/scheduler/main.py
@@ -380,6 +380,9 @@ def _trigger_scan(request, default_mode, default_tag):
       - scan_uuid, profile, target_url, target_name, target_urls
       - job_id, reporter_base_url
       - scan_mode, image_tag (override defaults from the environment function)
+      - spot (bool, default: false) — use SPOT pricing. Caller should only
+        enable after confirming capacity; SPOT VMs can be preempted immediately
+        in congested zones (#719)
 
     The per-environment function sets sensible defaults; the caller can
     override scan_mode/image_tag if needed (e.g., to control scan depth).
@@ -409,6 +412,7 @@ def _trigger_scan(request, default_mode, default_tag):
 
     job_id = data.get('job_id', '')
     reporter_base_url = data.get('reporter_base_url', '')
+    use_spot = data.get('spot', False)
 
     # Wrap single URL into JSON array for TARGET_URLS
     target_urls = data.get('target_urls')
@@ -430,8 +434,10 @@ def _trigger_scan(request, default_mode, default_tag):
 
     client = compute_v1.InstancesClient()
 
-    # Production uses spot pricing for ~60% cost savings
-    if scan_mode == 'production':
+    # SPOT pricing opt-in — caller must explicitly request it. SPOT VMs can
+    # be preempted within seconds in congested zones, causing silent scan
+    # failures. Default to on-demand for reliability. (#719)
+    if use_spot:
         scheduling = compute_v1.Scheduling(
             provisioning_model='SPOT',
             instance_termination_action='DELETE',

--- a/cloud/scheduler/test_main.py
+++ b/cloud/scheduler/test_main.py
@@ -732,7 +732,25 @@ class TestPerEnvironmentFunctions(unittest.TestCase):
 
     @patch('builtins.open', unittest.mock.mock_open(read_data='#!/bin/bash'))
     @patch('main.compute_v1.InstancesClient')
-    def test_production_uses_spot_pricing(self, mock_cls):
+    def test_spot_pricing_when_requested(self, mock_cls):
+        """SPOT pricing is opt-in via spot=True (#719)."""
+        client = MagicMock()
+        mock_cls.return_value = client
+        client.insert.return_value = MagicMock()
+
+        main.trigger_production(
+            _build_request('POST', '/', json_body={
+                'callback_url': 'https://orchestrator.example.com/callbacks',
+                'spot': True,
+            }))
+
+        instance = client.insert.call_args.kwargs['request']['instance_resource']
+        self.assertEqual(instance.scheduling.provisioning_model, 'SPOT')
+
+    @patch('builtins.open', unittest.mock.mock_open(read_data='#!/bin/bash'))
+    @patch('main.compute_v1.InstancesClient')
+    def test_production_defaults_to_on_demand(self, mock_cls):
+        """Production no longer uses SPOT by default (#719)."""
         client = MagicMock()
         mock_cls.return_value = client
         client.insert.return_value = MagicMock()
@@ -743,7 +761,10 @@ class TestPerEnvironmentFunctions(unittest.TestCase):
             }))
 
         instance = client.insert.call_args.kwargs['request']['instance_resource']
-        self.assertEqual(instance.scheduling.provisioning_model, 'SPOT')
+        self.assertNotEqual(
+            getattr(instance.scheduling, 'provisioning_model', None),
+            'SPOT',
+        )
 
     @patch('builtins.open', unittest.mock.mock_open(read_data='#!/bin/bash'))
     @patch('main.compute_v1.InstancesClient')


### PR DESCRIPTION
## Summary

Root cause of #710: production scan VMs used SPOT pricing unconditionally. GCP `us-central1-a` preempted VMs within 1-5 minutes (before scan container started), and `instance_termination_action=DELETE` auto-deleted them — leaving no trace.

**Evidence from GCE audit logs:**
- `scan-177-1775756816`: created 17:47:06, preempted 17:48:29 (82s)
- `scan-177-1775754344`: created ~17:05, preempted 17:07:17 (~2m)
- `scan-177-1775754111`: created ~17:06, preempted 17:11:31 (~5m)

**Fix:** SPOT pricing is now opt-in via `spot: true` in the trigger request body. Defaults to on-demand for reliability. Callers can implement retry logic (on-demand first, SPOT for cost savings when capacity is confirmed).

Closes #719, closes #710

## Test plan

- [x] 51 Python tests pass — new tests for SPOT opt-in and on-demand default
- [ ] CI passes
- [ ] Deploy Cloud Functions → trigger scan → verify VM uses on-demand (no preemption)
- [ ] Trigger with `spot: true` → verify VM uses SPOT pricing

🤖 Generated with [Claude Code](https://claude.com/claude-code)