### PR TITLE
fix: multi-region zone fallback + error handling for VM creation (#710)

### DIFF
--- a/.woodpecker/ci.yaml
+++ b/.woodpecker/ci.yaml
@@ -7,7 +7,6 @@ when:
 labels:
   platform: linux
   backend: local
-  tier: ondemand
 
 steps:
   - name: check-release-notes

--- a/.woodpecker/ci.yaml
+++ b/.woodpecker/ci.yaml
@@ -7,6 +7,7 @@ when:
 labels:
   platform: linux
   backend: local
+  tier: ondemand
 
 steps:
   - name: check-release-notes

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,7 +2,6 @@
 
 ## Unreleased
 
-- fix: CI workflow runs on on-demand VMs to avoid spot preemption (#726)
 - fix: scan VMs fail on zone exhaustion — on-demand only, multi-region zone fallback (9 zones), structured 503 on total failure (#710, #719)
 - fix: VM startup failure observability — Cloud Function writes vm-created marker to GCS, EXIT trap sends failure callback to orchestrator (#711)
 - fix: revert promote depends_on deploy — deploy only runs on staging, blocking dev→staging promotion (#691)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- fix: scan VMs preempted immediately — SPOT pricing now opt-in, defaults to on-demand for reliability (#719)
+- fix: scan VMs fail on zone exhaustion — on-demand only, multi-region zone fallback (9 zones), structured 503 on total failure (#710, #719)
 - fix: VM startup failure observability — Cloud Function writes vm-created marker to GCS, EXIT trap sends failure callback to orchestrator (#711)
 - fix: revert promote depends_on deploy — deploy only runs on staging, blocking dev→staging promotion (#691)
 - fix: heartbeat stops updating during long Nuclei scans — chunked stdout reading yields GIL to heartbeat thread (#697)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- fix: CI workflow runs on on-demand VMs to avoid spot preemption (#726)
 - fix: scan VMs fail on zone exhaustion — on-demand only, multi-region zone fallback (9 zones), structured 503 on total failure (#710, #719)
 - fix: VM startup failure observability — Cloud Function writes vm-created marker to GCS, EXIT trap sends failure callback to orchestrator (#711)
 - fix: revert promote depends_on deploy — deploy only runs on staging, blocking dev→staging promotion (#691)

--- a/cloud/scheduler/main.py
+++ b/cloud/scheduler/main.py
@@ -13,7 +13,15 @@ from google.cloud import compute_v1
 PROJECT = os.environ.get('GCP_PROJECT', 'peregrine-pentest-dev')
 REGION = os.environ.get('GCP_REGION', 'us-central1')
 ZONE = os.environ.get('GCP_ZONE', 'us-central1-a')
-MACHINE_TYPE = f'zones/{ZONE}/machineTypes/e2-standard-4'
+# Zone fallback order: primary zone, then same-region alternates, then
+# cross-region zones. Scan VMs are stateless — any zone works. (#710)
+FALLBACK_ZONES = os.environ.get('FALLBACK_ZONES', ','.join([
+    'us-central1-a', 'us-central1-b', 'us-central1-f',
+    'us-east1-b', 'us-east1-c',
+    'us-west1-a', 'us-west1-b',
+    'us-east4-a', 'us-east4-b',
+])).split(',')
+MACHINE_TYPE_NAME = 'e2-standard-4'
 SERVICE_ACCOUNT = f'pentest-scanner@{PROJECT}.iam.gserviceaccount.com'
 IMAGE_FAMILY = 'ubuntu-2204-lts'
 IMAGE_PROJECT = 'ubuntu-os-cloud'
@@ -380,9 +388,6 @@ def _trigger_scan(request, default_mode, default_tag):
       - scan_uuid, profile, target_url, target_name, target_urls
       - job_id, reporter_base_url
       - scan_mode, image_tag (override defaults from the environment function)
-      - spot (bool, default: false) — use SPOT pricing. Caller should only
-        enable after confirming capacity; SPOT VMs can be preempted immediately
-        in congested zones (#719)
 
     The per-environment function sets sensible defaults; the caller can
     override scan_mode/image_tag if needed (e.g., to control scan depth).
@@ -412,7 +417,6 @@ def _trigger_scan(request, default_mode, default_tag):
 
     job_id = data.get('job_id', '')
     reporter_base_url = data.get('reporter_base_url', '')
-    use_spot = data.get('spot', False)
 
     # Wrap single URL into JSON array for TARGET_URLS
     target_urls = data.get('target_urls')
@@ -434,80 +438,95 @@ def _trigger_scan(request, default_mode, default_tag):
 
     client = compute_v1.InstancesClient()
 
-    # SPOT pricing opt-in — caller must explicitly request it. SPOT VMs can
-    # be preempted within seconds in congested zones, causing silent scan
-    # failures. Default to on-demand for reliability. (#719)
-    if use_spot:
-        scheduling = compute_v1.Scheduling(
-            provisioning_model='SPOT',
-            instance_termination_action='DELETE',
-        )
-    else:
-        scheduling = compute_v1.Scheduling()
+    scheduling = compute_v1.Scheduling()
 
-    instance = compute_v1.Instance(
-        name=instance_name,
-        machine_type=MACHINE_TYPE,
-        disks=[compute_v1.AttachedDisk(
-            auto_delete=True,
-            boot=True,
-            initialize_params=compute_v1.AttachedDiskInitializeParams(
-                source_image=f'projects/{IMAGE_PROJECT}/global/images/family/{IMAGE_FAMILY}',
-                disk_size_gb=30,
-                disk_type=f'zones/{ZONE}/diskTypes/pd-standard',
-            ),
-        )],
-        network_interfaces=[compute_v1.NetworkInterface(
-            name='global/networks/default',
-            access_configs=[compute_v1.AccessConfig(
-                name='External NAT',
-                type_='ONE_TO_ONE_NAT',
+    # Try each zone in FALLBACK_ZONES until one has capacity (#710)
+    created_zone = None
+    last_error = None
+    for zone in FALLBACK_ZONES:
+        instance = compute_v1.Instance(
+            name=instance_name,
+            machine_type=f'zones/{zone}/machineTypes/{MACHINE_TYPE_NAME}',
+            disks=[compute_v1.AttachedDisk(
+                auto_delete=True,
+                boot=True,
+                initialize_params=compute_v1.AttachedDiskInitializeParams(
+                    source_image=f'projects/{IMAGE_PROJECT}/global/images/family/{IMAGE_FAMILY}',
+                    disk_size_gb=30,
+                    disk_type=f'zones/{zone}/diskTypes/pd-standard',
+                ),
             )],
-        )],
-        service_accounts=[compute_v1.ServiceAccount(
-            email=SERVICE_ACCOUNT,
-            scopes=['https://www.googleapis.com/auth/cloud-platform'],
-        )],
-        metadata=compute_v1.Metadata(items=[
-            compute_v1.Items(key='SCAN_MODE', value=scan_mode),
-            compute_v1.Items(key='SCAN_PROFILE', value=profile),
-            compute_v1.Items(key='TARGET_NAME', value=target_name),
-            compute_v1.Items(key='TARGET_URLS', value=target_urls),
-            compute_v1.Items(key='SCAN_UUID', value=scan_uuid),
-            compute_v1.Items(key='CALLBACK_URL', value=callback_url),
-            compute_v1.Items(key='JOB_ID', value=job_id),
-            compute_v1.Items(
-                key='REPORTER_BASE_URL', value=reporter_base_url,
-            ),
-            compute_v1.Items(
-                key='GCS_BUCKET',
-                value=f'{PROJECT}-pentest-reports',
-            ),
-            compute_v1.Items(
-                key='REGISTRY',
-                value=f'us-central1-docker.pkg.dev/{PROJECT}/pentest',
-            ),
-            compute_v1.Items(key='IMAGE_TAG', value=image_tag),
-            compute_v1.Items(key='startup-script', value=startup_script),
-        ]),
-        scheduling=scheduling,
-        labels={
-            'env': scan_mode,
-            'project': 'pentest',
-            'scan': 'true',
-            'profile': profile,
-        },
-        tags=compute_v1.Tags(items=['pentest-scan']),
-    )
+            network_interfaces=[compute_v1.NetworkInterface(
+                name='global/networks/default',
+                access_configs=[compute_v1.AccessConfig(
+                    name='External NAT',
+                    type_='ONE_TO_ONE_NAT',
+                )],
+            )],
+            service_accounts=[compute_v1.ServiceAccount(
+                email=SERVICE_ACCOUNT,
+                scopes=['https://www.googleapis.com/auth/cloud-platform'],
+            )],
+            metadata=compute_v1.Metadata(items=[
+                compute_v1.Items(key='SCAN_MODE', value=scan_mode),
+                compute_v1.Items(key='SCAN_PROFILE', value=profile),
+                compute_v1.Items(key='TARGET_NAME', value=target_name),
+                compute_v1.Items(key='TARGET_URLS', value=target_urls),
+                compute_v1.Items(key='SCAN_UUID', value=scan_uuid),
+                compute_v1.Items(key='CALLBACK_URL', value=callback_url),
+                compute_v1.Items(key='JOB_ID', value=job_id),
+                compute_v1.Items(
+                    key='REPORTER_BASE_URL', value=reporter_base_url,
+                ),
+                compute_v1.Items(
+                    key='GCS_BUCKET',
+                    value=f'{PROJECT}-pentest-reports',
+                ),
+                compute_v1.Items(
+                    key='REGISTRY',
+                    value=f'us-central1-docker.pkg.dev/{PROJECT}/pentest',
+                ),
+                compute_v1.Items(key='IMAGE_TAG', value=image_tag),
+                compute_v1.Items(key='startup-script', value=startup_script),
+            ]),
+            scheduling=scheduling,
+            labels={
+                'env': scan_mode,
+                'project': 'pentest',
+                'scan': 'true',
+                'profile': profile,
+            },
+            tags=compute_v1.Tags(items=['pentest-scan']),
+        )
 
-    operation = client.insert(
-        request={
-            'project': PROJECT,
-            'zone': ZONE,
-            'instance_resource': instance,
-        }
-    )
-    operation.result()
+        try:
+            operation = client.insert(
+                request={
+                    'project': PROJECT,
+                    'zone': zone,
+                    'instance_resource': instance,
+                }
+            )
+            operation.result()
+            created_zone = zone
+            break
+        except Exception as e:
+            last_error = str(e)
+            print(f'[trigger-scan-{scan_mode}] Zone {zone} failed: '
+                  f'{last_error[:200]}')
+
+    if not created_zone:
+        _slack_notify(
+            f':x: VM creation failed for {scan_uuid} in all zones: '
+            f'{last_error[:200]}')
+        return json.dumps({
+            'error': f'VM creation failed in all zones: {last_error}',
+            'scan_uuid': scan_uuid,
+        }), 503, {'Content-Type': 'application/json'}
+
+    if created_zone != FALLBACK_ZONES[0]:
+        print(f'[trigger-scan-{scan_mode}] Created in fallback zone '
+              f'{created_zone} (primary {FALLBACK_ZONES[0]} exhausted)')
 
     # Write vm-created marker to GCS — closes the observability gap between
     # VM creation (confirmed by GCP API) and first heartbeat (~30s later).
@@ -519,4 +538,5 @@ def _trigger_scan(request, default_mode, default_tag):
         'scan_uuid': scan_uuid,
         'status': 'accepted',
         'instance_name': instance_name,
+        'zone': created_zone,
     }), 200, {'Content-Type': 'application/json'}

--- a/cloud/scheduler/test_main.py
+++ b/cloud/scheduler/test_main.py
@@ -638,6 +638,56 @@ class TestTriggerProduction(unittest.TestCase):
         self.assertEqual(args[0], 'scan-test711')
         self.assertIn('pentest-scan-', args[1])
 
+    @patch('builtins.open', unittest.mock.mock_open(read_data='#!/bin/bash\necho hi'))
+    @patch('main.compute_v1.InstancesClient')
+    def test_returns_503_when_all_zones_exhausted(self, mock_client_cls):
+        """VM creation failure in all zones returns 503 (#710)."""
+        from google.api_core.exceptions import ServiceUnavailable
+        client = MagicMock()
+        mock_client_cls.return_value = client
+        op = MagicMock()
+        op.result.side_effect = ServiceUnavailable('ZONE_RESOURCE_POOL_EXHAUSTED')
+        client.insert.return_value = op
+
+        body, code, headers = main.trigger_production(
+            _build_request('POST', '/', json_body={
+                'scan_uuid': 'scan-fail503',
+                'callback_url': 'https://orchestrator.example.com/callbacks',
+            }))
+        result = json.loads(body)
+
+        self.assertEqual(code, 503)
+        self.assertIn('VM creation failed', result['error'])
+        self.assertEqual(result['scan_uuid'], 'scan-fail503')
+        # Should have tried all fallback zones
+        self.assertEqual(client.insert.call_count, len(main.FALLBACK_ZONES))
+        self._mock_write.assert_not_called()
+
+    @patch('builtins.open', unittest.mock.mock_open(read_data='#!/bin/bash\necho hi'))
+    @patch('main.compute_v1.InstancesClient')
+    def test_falls_back_to_next_zone_on_exhaustion(self, mock_client_cls):
+        """Zone fallback: first zone fails, second succeeds (#710)."""
+        from google.api_core.exceptions import ServiceUnavailable
+        client = MagicMock()
+        mock_client_cls.return_value = client
+
+        fail_op = MagicMock()
+        fail_op.result.side_effect = ServiceUnavailable('EXHAUSTED')
+        ok_op = MagicMock()
+        ok_op.result.return_value = None
+        client.insert.side_effect = [fail_op, ok_op]
+
+        body, code, headers = main.trigger_production(
+            _build_request('POST', '/', json_body={
+                'callback_url': 'https://orchestrator.example.com/callbacks',
+            }))
+        result = json.loads(body)
+
+        self.assertEqual(code, 200)
+        self.assertEqual(result['status'], 'accepted')
+        self.assertEqual(result['zone'], main.FALLBACK_ZONES[1])
+        self.assertEqual(client.insert.call_count, 2)
+
 
 class TestWriteVmCreated(unittest.TestCase):
     """_write_vm_created writes a GCS marker after VM provisioning (#711)."""
@@ -732,48 +782,13 @@ class TestPerEnvironmentFunctions(unittest.TestCase):
 
     @patch('builtins.open', unittest.mock.mock_open(read_data='#!/bin/bash'))
     @patch('main.compute_v1.InstancesClient')
-    def test_spot_pricing_when_requested(self, mock_cls):
-        """SPOT pricing is opt-in via spot=True (#719)."""
+    def test_always_uses_on_demand_scheduling(self, mock_cls):
+        """All VMs use on-demand — no SPOT pricing (#710, #719)."""
         client = MagicMock()
         mock_cls.return_value = client
         client.insert.return_value = MagicMock()
 
         main.trigger_production(
-            _build_request('POST', '/', json_body={
-                'callback_url': 'https://orchestrator.example.com/callbacks',
-                'spot': True,
-            }))
-
-        instance = client.insert.call_args.kwargs['request']['instance_resource']
-        self.assertEqual(instance.scheduling.provisioning_model, 'SPOT')
-
-    @patch('builtins.open', unittest.mock.mock_open(read_data='#!/bin/bash'))
-    @patch('main.compute_v1.InstancesClient')
-    def test_production_defaults_to_on_demand(self, mock_cls):
-        """Production no longer uses SPOT by default (#719)."""
-        client = MagicMock()
-        mock_cls.return_value = client
-        client.insert.return_value = MagicMock()
-
-        main.trigger_production(
-            _build_request('POST', '/', json_body={
-                'callback_url': 'https://orchestrator.example.com/callbacks',
-            }))
-
-        instance = client.insert.call_args.kwargs['request']['instance_resource']
-        self.assertNotEqual(
-            getattr(instance.scheduling, 'provisioning_model', None),
-            'SPOT',
-        )
-
-    @patch('builtins.open', unittest.mock.mock_open(read_data='#!/bin/bash'))
-    @patch('main.compute_v1.InstancesClient')
-    def test_staging_does_not_use_spot_pricing(self, mock_cls):
-        client = MagicMock()
-        mock_cls.return_value = client
-        client.insert.return_value = MagicMock()
-
-        main.trigger_staging(
             _build_request('POST', '/', json_body={
                 'callback_url': 'https://orchestrator.example.com/callbacks',
             }))


### PR DESCRIPTION
## Summary

Root cause of #710: `ZONE_RESOURCE_POOL_EXHAUSTED` in us-central1-a caused unhandled exceptions from `operation.result()`, returning 500 to the caller. Additionally, SPOT pricing caused immediate preemption.

**Changes:**
- Remove SPOT pricing entirely — always on-demand (infrastructure decision, not caller's)
- Remove `spot` parameter from the trigger API — callers shouldn't control VM type
- Try 9 zones across 4 regions (us-central1, us-east1, us-west1, us-east4) before failing
- Return structured 503 with `scan_uuid` on total failure (not unhandled 500)
- Include `zone` in success response for diagnostics
- Configurable via `FALLBACK_ZONES` env var

Closes #710

## Test plan

- [x] 51 Python tests pass — zone fallback, all-zones-exhausted 503, on-demand scheduling
- [ ] CI passes
- [ ] Deploy Cloud Functions → trigger scan → verify VM created (even if primary zone exhausted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)