### PR TITLE
fix: callback URL path doubled — /callbacks/callbacks/heartbeat (#728)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- fix: callback URL path doubled — `/callbacks/callbacks/heartbeat` — treat CALLBACK_URL as base, append only endpoint suffix; fix vm-startup.sh auth header (#728)
 - fix: scan VMs preempted immediately — SPOT pricing now opt-in, defaults to on-demand for reliability (#719)
 - fix: VM startup failure observability — Cloud Function writes vm-created marker to GCS, EXIT trap sends failure callback to orchestrator (#711)
 - fix: revert promote depends_on deploy — deploy only runs on staging, blocking dev→staging promotion (#691)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- fix: callback URL path doubled — `/callbacks/callbacks/heartbeat` — treat CALLBACK_URL as base, append only endpoint suffix; fix vm-startup.sh auth header (#728)
+- fix: callback URL path doubled — `/callbacks/callbacks/heartbeat` — treat CALLBACK_URL as base, append only endpoint suffix; fix vm-startup.sh auth header (#728) 
 - fix: scan VMs preempted immediately — SPOT pricing now opt-in, defaults to on-demand for reliability (#719)
 - fix: VM startup failure observability — Cloud Function writes vm-created marker to GCS, EXIT trap sends failure callback to orchestrator (#711)
 - fix: revert promote depends_on deploy — deploy only runs on staging, blocking dev→staging promotion (#691)

--- a/app/services/heartbeat_sender.rb
+++ b/app/services/heartbeat_sender.rb
@@ -44,9 +44,8 @@ class HeartbeatSender
   private
 
   def derive_heartbeat_url(callback_url)
-    uri = URI.parse(callback_url)
-    "#{uri.scheme}://#{uri.host}#{":#{uri.port}" unless [80, 443].include?(uri.port)}/callbacks/heartbeat"
-  rescue URI::InvalidURIError
+    "#{callback_url.chomp('/')}/heartbeat"
+  rescue StandardError
     ''
   end
 

--- a/app/services/scan_callback_service.rb
+++ b/app/services/scan_callback_service.rb
@@ -97,7 +97,7 @@ class ScanCallbackService
   end
 
   def callback_url
-    ENV.fetch('CALLBACK_URL')
+    ENV.fetch('CALLBACK_URL').chomp('/') + '/scan_complete'
   end
 
   def callback_secret

--- a/app/services/scan_callback_service.rb
+++ b/app/services/scan_callback_service.rb
@@ -97,7 +97,7 @@ class ScanCallbackService
   end
 
   def callback_url
-    ENV.fetch('CALLBACK_URL').chomp('/') + '/scan_complete'
+    "#{ENV.fetch('CALLBACK_URL').chomp('/')}/scan_complete"
   end
 
   def callback_secret

--- a/cloud/scheduler/vm-startup.sh
+++ b/cloud/scheduler/vm-startup.sh
@@ -68,10 +68,10 @@ send_failure_callback() {
   # status.json already has the failure recorded for scavenger/debugging
   curl -sf -X POST \
     -H 'Content-Type: application/json' \
-    -H "X-Callback-Secret: ${callback_secret}" \
+    -H "Authorization: Bearer ${callback_secret}" \
     --max-time 10 \
     -d "${payload}" \
-    "${callback_url}/heartbeat" 2>/dev/null || true
+    "${callback_url}/scan_complete" 2>/dev/null || true
 }
 
 # Self-terminate on failure for scan VMs (prevents orphaned VMs incurring cost)

--- a/spec/services/heartbeat_sender_spec.rb
+++ b/spec/services/heartbeat_sender_spec.rb
@@ -3,7 +3,7 @@ require 'sequel_helper'
 RSpec.describe HeartbeatSender do
   let(:sender) do
     described_class.new(
-      callback_url: 'https://reporter.example.com/callbacks/scan_complete?job_id=j1',
+      callback_url: 'https://reporter.example.com/callbacks',
       scan_uuid: 'scan-123',
       job_id: 'job-456',
       callback_secret: 'secret-token'

--- a/spec/services/scan_callback_service_spec.rb
+++ b/spec/services/scan_callback_service_spec.rb
@@ -10,7 +10,8 @@ RSpec.describe ScanCallbackService do
                   summary: { 'total_findings' => 5, 'by_severity' => { 'high' => 2, 'medium' => 3 } })
   end
   let(:cost_logger) { ScanCostLogger.new(scan) }
-  let(:callback_url) { 'https://api.peregrine-tech.com/internal/scans/abc-123/complete' }
+  let(:callback_url) { 'https://api.peregrine-tech.com/callbacks' }
+  let(:scan_complete_url) { 'https://api.peregrine-tech.com/callbacks/scan_complete' }
   let(:callback_secret) { 'test-shared-secret-key' }
 
   before do
@@ -25,22 +26,22 @@ RSpec.describe ScanCallbackService do
     before { allow_any_instance_of(described_class).to receive(:sleep) } # rubocop:disable RSpec/AnyInstance
 
     it 'POSTs scan summary to the callback URL' do
-      stub_request(:post, callback_url).to_return(status: 200, body: '{"ok":true}')
+      stub_request(:post, scan_complete_url).to_return(status: 200, body: '{"ok":true}')
 
       service = described_class.new(scan, cost_logger)
       result = service.notify
 
       expect(result).to be true
-      expect(WebMock).to have_requested(:post, callback_url).once
+      expect(WebMock).to have_requested(:post, scan_complete_url).once
     end
 
     it 'includes scan summary in the payload' do
-      stub_request(:post, callback_url).to_return(status: 200, body: '{"ok":true}')
+      stub_request(:post, scan_complete_url).to_return(status: 200, body: '{"ok":true}')
 
       service = described_class.new(scan, cost_logger)
       service.notify
 
-      expect(WebMock).to(have_requested(:post, callback_url).with do |req|
+      expect(WebMock).to(have_requested(:post, scan_complete_url).with do |req|
         body = JSON.parse(req.body)
         body['scan_uuid'] == 'abc-123' &&
           body['status'] == 'completed' &&
@@ -49,42 +50,42 @@ RSpec.describe ScanCallbackService do
     end
 
     it 'includes cost data in the payload' do
-      stub_request(:post, callback_url).to_return(status: 200, body: '{"ok":true}')
+      stub_request(:post, scan_complete_url).to_return(status: 200, body: '{"ok":true}')
       cost_logger.track_anthropic_tokens(2000)
 
       service = described_class.new(scan, cost_logger)
       service.notify
 
-      expect(WebMock).to(have_requested(:post, callback_url).with do |req|
+      expect(WebMock).to(have_requested(:post, scan_complete_url).with do |req|
         body = JSON.parse(req.body)
         body['cost_data']['anthropic_tokens_used'] == 2000
       end)
     end
 
     it 'authenticates with shared secret in Authorization header' do
-      stub_request(:post, callback_url).to_return(status: 200, body: '{"ok":true}')
+      stub_request(:post, scan_complete_url).to_return(status: 200, body: '{"ok":true}')
 
       service = described_class.new(scan, cost_logger)
       service.notify
 
-      expect(WebMock).to have_requested(:post, callback_url).with(
+      expect(WebMock).to have_requested(:post, scan_complete_url).with(
         headers: { 'Authorization' => "Bearer #{callback_secret}" }
       )
     end
 
     it 'sends Content-Type application/json' do
-      stub_request(:post, callback_url).to_return(status: 200, body: '{"ok":true}')
+      stub_request(:post, scan_complete_url).to_return(status: 200, body: '{"ok":true}')
 
       service = described_class.new(scan, cost_logger)
       service.notify
 
-      expect(WebMock).to have_requested(:post, callback_url).with(
+      expect(WebMock).to have_requested(:post, scan_complete_url).with(
         headers: { 'Content-Type' => 'application/json' }
       )
     end
 
     it 'retries up to 3 times on failure' do
-      stub_request(:post, callback_url)
+      stub_request(:post, scan_complete_url)
         .to_return(status: 500).then
         .to_return(status: 500).then
         .to_return(status: 200, body: '{"ok":true}')
@@ -93,21 +94,21 @@ RSpec.describe ScanCallbackService do
       result = service.notify
 
       expect(result).to be true
-      expect(WebMock).to have_requested(:post, callback_url).times(3)
+      expect(WebMock).to have_requested(:post, scan_complete_url).times(3)
     end
 
     it 'returns false after exhausting retries' do
-      stub_request(:post, callback_url).to_return(status: 500)
+      stub_request(:post, scan_complete_url).to_return(status: 500)
 
       service = described_class.new(scan, cost_logger)
       result = service.notify
 
       expect(result).to be false
-      expect(WebMock).to have_requested(:post, callback_url).times(3)
+      expect(WebMock).to have_requested(:post, scan_complete_url).times(3)
     end
 
     it 'returns false and logs error on network failure' do
-      stub_request(:post, callback_url).to_raise(Faraday::ConnectionFailed.new('connection refused'))
+      stub_request(:post, scan_complete_url).to_raise(Faraday::ConnectionFailed.new('connection refused'))
 
       service = described_class.new(scan, cost_logger)
       expect(Penetrator.logger).to receive(:error).with(/ScanCallbackService/).at_least(:once)
@@ -123,41 +124,41 @@ RSpec.describe ScanCallbackService do
       result = service.notify
 
       expect(result).to be false
-      expect(WebMock).not_to have_requested(:post, callback_url)
+      expect(WebMock).not_to have_requested(:post, scan_complete_url)
     end
 
     it 'includes gcs_scan_results_path when provided' do
-      stub_request(:post, callback_url).to_return(status: 200, body: '{"ok":true}')
+      stub_request(:post, scan_complete_url).to_return(status: 200, body: '{"ok":true}')
       gcs_path = 'scan-results/target-1/scan-1/scan_results.json'
 
       service = described_class.new(scan, cost_logger, gcs_scan_results_path: gcs_path)
       service.notify
 
-      expect(WebMock).to(have_requested(:post, callback_url).with do |req|
+      expect(WebMock).to(have_requested(:post, scan_complete_url).with do |req|
         body = JSON.parse(req.body)
         body['gcs_scan_results_path'] == gcs_path
       end)
     end
 
     it 'omits gcs_scan_results_path when not provided' do
-      stub_request(:post, callback_url).to_return(status: 200, body: '{"ok":true}')
+      stub_request(:post, scan_complete_url).to_return(status: 200, body: '{"ok":true}')
 
       service = described_class.new(scan, cost_logger)
       service.notify
 
-      expect(WebMock).to(have_requested(:post, callback_url).with do |req|
+      expect(WebMock).to(have_requested(:post, scan_complete_url).with do |req|
         body = JSON.parse(req.body)
         !body.key?('gcs_scan_results_path')
       end)
     end
 
     it 'includes scan duration in the payload' do
-      stub_request(:post, callback_url).to_return(status: 200, body: '{"ok":true}')
+      stub_request(:post, scan_complete_url).to_return(status: 200, body: '{"ok":true}')
 
       service = described_class.new(scan, cost_logger)
       service.notify
 
-      expect(WebMock).to(have_requested(:post, callback_url).with do |req|
+      expect(WebMock).to(have_requested(:post, scan_complete_url).with do |req|
         body = JSON.parse(req.body)
         body['duration_seconds'].is_a?(Numeric)
       end)
@@ -190,7 +191,7 @@ RSpec.describe ScanCallbackService do
       result = service.notify
 
       expect(result).to be true
-      expect(WebMock).not_to have_requested(:post, callback_url)
+      expect(WebMock).not_to have_requested(:post, scan_complete_url)
     end
   end
 


### PR DESCRIPTION
## Summary

- **HeartbeatSender**: `derive_heartbeat_url` stripped the path from CALLBACK_URL and hardcoded `/callbacks/heartbeat`. Now appends `/heartbeat` to CALLBACK_URL as-is.
- **ScanCallbackService**: Used CALLBACK_URL directly without appending `/scan_complete`. Now appends `/scan_complete`.
- **vm-startup.sh**: Fixed `X-Callback-Secret` header to `Authorization: Bearer` (matching Ruby services). Changed failure callback endpoint from `/heartbeat` to `/scan_complete`.

Closes #728

## Test plan

- [x] HeartbeatSender spec passes — heartbeat URL built correctly from base
- [x] ScanCallbackService spec passes — POSTs to `{CALLBACK_URL}/scan_complete`
- [x] 93% coverage, all 147 specs green
- [ ] Deploy to staging, verify orchestrator receives heartbeats and completion callbacks

🤖 Generated with [Claude Code](https://claude.com/claude-code)