### PR TITLE
feat: fingerprinter framework — base class, registry, generic fallback (#737)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- feat: fingerprinter framework (base class, registry, generic fallback) + orchestrator hook writes `cms_inventory` into `scan.summary` (#737)
 - fix: callback URL path doubled — `/callbacks/callbacks/heartbeat` — treat CALLBACK_URL as base, append only endpoint suffix; fix vm-startup.sh auth header (#728) 
 - fix: scan VMs preempted immediately — SPOT pricing now opt-in, defaults to on-demand for reliability (#719)
 - fix: CI workflow runs on on-demand VMs to avoid spot preemption (#726)

--- a/app/services/fingerprinters/fingerprinter_base.rb
+++ b/app/services/fingerprinters/fingerprinter_base.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+module Fingerprinters
+  class FingerprinterBase
+    MIN_CONFIDENCE = 0.5
+    HTTP_TIMEOUT = 5
+    HTTP_OPEN_TIMEOUT = 3
+
+    attr_reader :scan, :target, :logger
+
+    def initialize(scan)
+      @scan = scan
+      @target = scan.target
+      @logger = Penetrator.logger
+    end
+
+    def detect
+      raise NotImplementedError, 'Subclass must implement #detect'
+    end
+
+    def cms_name
+      raise NotImplementedError, 'Subclass must implement #cms_name'
+    end
+
+    protected
+
+    def empty_result
+      { cms: cms_name, confidence: 0.0, components: [] }
+    end
+
+    def http_get(url)
+      connection.get(url)
+    rescue StandardError => e
+      logger.debug("[#{cms_name}] GET #{url} failed: #{e.message}")
+      nil
+    end
+
+    def http_head(url)
+      connection.head(url)
+    rescue StandardError => e
+      logger.debug("[#{cms_name}] HEAD #{url} failed: #{e.message}")
+      nil
+    end
+
+    def connection
+      @connection ||= Faraday.new do |f|
+        f.adapter Faraday.default_adapter
+        f.options.timeout = HTTP_TIMEOUT
+        f.options.open_timeout = HTTP_OPEN_TIMEOUT
+        f.headers['User-Agent'] = 'Peregrine-Penetrator/1.0 (fingerprinter)'
+      end
+    end
+  end
+end

--- a/app/services/fingerprinters/fingerprinter_registry.rb
+++ b/app/services/fingerprinters/fingerprinter_registry.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module Fingerprinters
+  class FingerprinterRegistry
+    def self.detectors
+      @detectors ||= [GenericFingerprinter]
+    end
+
+    def self.register(detector_class)
+      return if detectors.include?(detector_class)
+
+      # Prepend so more-specific detectors run before the Generic fallback.
+      @detectors = [detector_class] + detectors
+    end
+
+    def self.reset!
+      @detectors = [GenericFingerprinter]
+    end
+
+    def initialize(scan)
+      @scan = scan
+    end
+
+    def detect
+      self.class.detectors.each do |detector_class|
+        result = safely_detect(detector_class)
+        return stamp(result) if result && result[:confidence].to_f >= FingerprinterBase::MIN_CONFIDENCE
+      end
+
+      stamp(GenericFingerprinter.new(@scan).detect)
+    end
+
+    private
+
+    def safely_detect(detector_class)
+      detector_class.new(@scan).detect
+    rescue StandardError => e
+      Penetrator.logger.warn("[FingerprinterRegistry] #{detector_class.name} raised: #{e.message}")
+      nil
+    end
+
+    def stamp(result)
+      result.merge(detected_at: Time.current.iso8601)
+    end
+  end
+end

--- a/app/services/fingerprinters/generic_fingerprinter.rb
+++ b/app/services/fingerprinters/generic_fingerprinter.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Fingerprinters
+  class GenericFingerprinter < FingerprinterBase
+    def detect
+      empty_result
+    end
+
+    def cms_name
+      'unknown'
+    end
+  end
+end

--- a/app/services/scan_orchestrator.rb
+++ b/app/services/scan_orchestrator.rb
@@ -58,8 +58,18 @@ class ScanOrchestrator
       run_smoke_checks
     else
       preflight_check
+      fingerprint_target
       run_scan_phases
     end
+  end
+
+  def fingerprint_target
+    result = Fingerprinters::FingerprinterRegistry.new(scan).detect
+    scan.summary = (scan.summary || {}).merge('cms_inventory' => result.transform_keys(&:to_s))
+    scan.save_changes
+    Penetrator.logger.info("[Fingerprint] CMS: #{result[:cms]} (confidence: #{result[:confidence]})")
+  rescue StandardError => e
+    Penetrator.logger.warn("[Fingerprint] Failed: #{e.message}")
   end
 
   def start_control_plane
@@ -141,14 +151,14 @@ class ScanOrchestrator
   def mark_completed
     scan.status = 'completed'
     scan.completed_at = Time.current
-    scan.summary = ScanSummaryBuilder.new(scan).build
+    scan.summary = (scan.summary || {}).merge(ScanSummaryBuilder.new(scan).build)
     scan.save_changes
   end
 
   def mark_cancelled
     scan.status = 'cancelled'
     scan.completed_at = Time.current
-    scan.summary = ScanSummaryBuilder.new(scan).build
+    scan.summary = (scan.summary || {}).merge(ScanSummaryBuilder.new(scan).build)
     scan.save_changes
     Penetrator.logger.info('[ScanOrchestrator] Scan cancelled by control plane')
   end

--- a/spec/services/fingerprinters/fingerprinter_base_spec.rb
+++ b/spec/services/fingerprinters/fingerprinter_base_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'sequel_helper'
+
+RSpec.describe Fingerprinters::FingerprinterBase do
+  let(:target) { create(:target, urls: ['https://example.com'].to_json) }
+  let(:scan) { create(:scan, target:) }
+
+  describe '#detect' do
+    it 'raises NotImplementedError in the base class' do
+      expect { described_class.new(scan).detect }.to raise_error(NotImplementedError)
+    end
+  end
+
+  describe '#cms_name' do
+    it 'raises NotImplementedError in the base class' do
+      expect { described_class.new(scan).cms_name }.to raise_error(NotImplementedError)
+    end
+  end
+
+  describe 'HTTP helpers' do
+    let(:detector_class) do
+      Class.new(described_class) do
+        def cms_name = 'test'
+        def detect = empty_result
+      end
+    end
+    let(:detector) { detector_class.new(scan) }
+
+    before do
+      # Expose the protected HTTP helpers on this anonymous subclass for direct testing.
+      detector_class.send(:public, :http_get, :http_head)
+    end
+
+    it 'returns the Faraday response on success' do
+      stub_request(:get, 'https://example.com/probe').to_return(status: 200, body: 'ok')
+      expect(detector.http_get('https://example.com/probe').status).to eq(200)
+    end
+
+    it 'returns nil and logs on failure' do
+      stub_request(:head, 'https://example.com/probe').to_raise(Faraday::ConnectionFailed.new('refused'))
+      expect(Penetrator.logger).to receive(:debug).with(/HEAD.*failed/)
+      expect(detector.http_head('https://example.com/probe')).to be_nil
+    end
+  end
+end

--- a/spec/services/fingerprinters/fingerprinter_registry_spec.rb
+++ b/spec/services/fingerprinters/fingerprinter_registry_spec.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require 'sequel_helper'
+
+RSpec.describe Fingerprinters::FingerprinterRegistry do
+  let(:target) { create(:target, urls: ['https://example.com'].to_json) }
+  let(:scan) { create(:scan, target:) }
+  let(:registry) { described_class.new(scan) }
+
+  before { described_class.reset! }
+  after { described_class.reset! }
+
+  def anonymous_detector(cms:, confidence:)
+    Class.new(Fingerprinters::FingerprinterBase) do
+      define_method(:cms_name) { cms }
+      define_method(:detect) { { cms:, confidence:, components: [] } }
+    end
+  end
+
+  describe '.detectors' do
+    it 'defaults to just the GenericFingerprinter' do
+      expect(described_class.detectors).to eq([Fingerprinters::GenericFingerprinter])
+    end
+  end
+
+  describe '.register' do
+    it 'prepends a detector ahead of the generic fallback' do
+      detector_class = anonymous_detector(cms: 'foo', confidence: 0.9)
+      described_class.register(detector_class)
+
+      expect(described_class.detectors.first).to eq(detector_class)
+      expect(described_class.detectors.last).to eq(Fingerprinters::GenericFingerprinter)
+    end
+
+    it 'is idempotent — registering the same detector twice leaves one copy' do
+      detector_class = anonymous_detector(cms: 'foo', confidence: 0.9)
+      described_class.register(detector_class)
+      described_class.register(detector_class)
+
+      expect(described_class.detectors.count(detector_class)).to eq(1)
+    end
+  end
+
+  describe '#detect' do
+    it 'returns the first detector result that meets the confidence threshold' do
+      described_class.register(anonymous_detector(cms: 'matched', confidence: 0.95))
+
+      result = registry.detect
+      expect(result[:cms]).to eq('matched')
+      expect(result[:confidence]).to eq(0.95)
+      expect(result[:detected_at]).to be_present
+    end
+
+    it 'falls back to GenericFingerprinter when no detector meets the threshold' do
+      described_class.register(anonymous_detector(cms: 'barely', confidence: 0.1))
+
+      result = registry.detect
+      expect(result[:cms]).to eq('unknown')
+      expect(result[:confidence]).to eq(0.0)
+    end
+
+    it 'skips detectors that raise, then tries the next one' do
+      raising = Class.new(Fingerprinters::FingerprinterBase) do
+        def cms_name = 'raising'
+        def detect = raise('boom')
+      end
+      matching = anonymous_detector(cms: 'matched', confidence: 0.9)
+
+      described_class.register(matching)
+      described_class.register(raising)
+
+      expect(Penetrator.logger).to receive(:warn).with(/raised: boom/).at_least(:once)
+      result = registry.detect
+      expect(result[:cms]).to eq('matched')
+    end
+
+    it 'does not abort when every registered detector raises' do
+      raising = Class.new(Fingerprinters::FingerprinterBase) do
+        def cms_name = 'raising'
+        def detect = raise('boom')
+      end
+      described_class.register(raising)
+
+      allow(Penetrator.logger).to receive(:warn)
+      expect { registry.detect }.not_to raise_error
+    end
+  end
+end

--- a/spec/services/fingerprinters/generic_fingerprinter_spec.rb
+++ b/spec/services/fingerprinters/generic_fingerprinter_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'sequel_helper'
+
+RSpec.describe Fingerprinters::GenericFingerprinter do
+  let(:target) { create(:target, urls: ['https://example.com'].to_json) }
+  let(:scan) { create(:scan, target:) }
+  let(:detector) { described_class.new(scan) }
+
+  describe '#cms_name' do
+    it 'returns unknown' do
+      expect(detector.cms_name).to eq('unknown')
+    end
+  end
+
+  describe '#detect' do
+    it 'returns an empty result with cms unknown and zero confidence' do
+      expect(detector.detect).to eq(cms: 'unknown', confidence: 0.0, components: [])
+    end
+  end
+end

--- a/spec/services/scan_orchestrator_spec.rb
+++ b/spec/services/scan_orchestrator_spec.rb
@@ -210,6 +210,41 @@ RSpec.describe ScanOrchestrator do
       expect(scan.status).to eq('failed')
       expect(scan.error_message).to include('Something broke')
     end
+
+    context 'when fingerprinting the target' do
+      it 'runs fingerprinting and stores cms_inventory on scan.summary' do
+        orchestrator.execute
+
+        scan.refresh
+        expect(scan.summary['cms_inventory']).to include('cms' => 'unknown', 'confidence' => 0.0)
+      end
+
+      it 'preserves cms_inventory in summary after scan completion' do
+        orchestrator.execute
+
+        scan.refresh
+        expect(scan.summary).to include('cms_inventory', 'total_findings')
+      end
+
+      it 'does not abort the scan when fingerprinting raises' do
+        registry = instance_double(Fingerprinters::FingerprinterRegistry)
+        allow(Fingerprinters::FingerprinterRegistry).to receive(:new).and_return(registry)
+        allow(registry).to receive(:detect).and_raise(StandardError, 'detector blew up')
+
+        expect { orchestrator.execute }.not_to raise_error
+        scan.refresh
+        expect(scan.status).to eq('completed')
+      end
+
+      it 'skips fingerprinting on smoke profiles' do
+        smoke_profile = instance_double(ScanProfile, name: 'smoke', smoke: true, smoke_test: false, phases: [])
+        allow(ScanProfile).to receive(:load).and_return(smoke_profile)
+        allow(SmokeChecker).to receive(:new).and_return(instance_double(SmokeChecker, run: {}, passed?: true, results: {}))
+
+        expect(Fingerprinters::FingerprinterRegistry).not_to receive(:new)
+        orchestrator.execute
+      end
+    end
   end
 
   private


### PR DESCRIPTION
## Summary

Lands the fingerprinter framework under epic #736:
- `FingerprinterBase` — abstract interface + shared HTTP helpers (Faraday)
- `FingerprinterRegistry` — ordered chain of detectors, safely handles per-detector failures, falls back to Generic when nothing meets the confidence threshold
- `GenericFingerprinter` — fallback returning `{cms: 'unknown', confidence: 0.0, components: []}`
- `ScanOrchestrator#fingerprint_target` hook runs between preflight and the phase loop, writes result into `scan.summary['cms_inventory']`
- `mark_completed` / `mark_cancelled` now merge summary instead of replacing (preserves `cms_inventory` and any future sidecar data)

**No concrete WordPress detector yet** — that's sub-issue #738. This PR is framework-only, so Generic is the only registered detector and every scan gets `cms_inventory.cms = 'unknown'` until #738 lands.

## Test plan

- [x] `bundle exec rspec` — 555 examples, 0 failures, 93.83% line coverage
- [x] `bundle exec rubocop` — no offences on changed files
- [x] Pre-commit hook green (tests + coverage + PDF generation)

## Not in this PR
- WordPress CMS detector (#738)
- Plugin/theme enumeration (#739, blocked by cve-watch#2)
- Schema version bump + envelope key (#740)
- Opt-in Nuclei auto-templates (#741)

Part of epic #736.