### PR TITLE
feat: WordPress CMS detector — core-level verdict + version (#738)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- feat: WordPress CMS detector — generator meta + wp-content/wp-includes + wp-json REST + readme/wp-login probes with weighted confidence scoring and core-version extraction (#738)
 - feat: fingerprinter framework (base class, registry, generic fallback) + orchestrator hook writes `cms_inventory` into `scan.summary` (#737)
 - fix: callback URL path doubled — `/callbacks/callbacks/heartbeat` — treat CALLBACK_URL as base, append only endpoint suffix; fix vm-startup.sh auth header (#728) 
 - fix: scan VMs preempted immediately — SPOT pricing now opt-in, defaults to on-demand for reliability (#719)

--- a/app/services/fingerprinters/wordpress_fingerprinter.rb
+++ b/app/services/fingerprinters/wordpress_fingerprinter.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+module Fingerprinters
+  class WordpressFingerprinter < FingerprinterBase
+    CONFIG_PATH = Penetrator.root.join('config/fingerprints/wordpress/core.yml')
+
+    def cms_name = 'wordpress'
+
+    def detect
+      base_url = target.url_list.first
+      return empty_result if base_url.nil?
+
+      uri = parse_uri(base_url)
+      return empty_result if uri.nil?
+
+      hits = evaluate_signatures(base_url, uri)
+      confidence = [hits.values.sum { |h| h[:weight] }, 1.0].min
+
+      result = { cms: cms_name, confidence:, components: [] }
+      core_version = hits.dig(:generator_meta, :version)
+      result[:core_version] = core_version if core_version
+      result
+    end
+
+    private
+
+    def evaluate_signatures(base_url, uri)
+      html = fetch_body(base_url)
+      {
+        generator_meta: evaluate_generator_meta(html),
+        wp_content_path: evaluate_html_substring(html, 'wp_content_path'),
+        wp_includes_path: evaluate_html_substring(html, 'wp_includes_path'),
+        wp_json_rest: evaluate_wp_json(uri),
+        readme_html: evaluate_body_contains(uri, 'readme_html', 'WordPress'),
+        wp_login: evaluate_body_contains(uri, 'wp_login', /wordpress/i)
+      }.compact
+    end
+
+    def evaluate_generator_meta(html)
+      match = html.match(Regexp.new(config['generator_meta']['pattern'], Regexp::IGNORECASE))
+      return nil unless match
+
+      hit = { weight: weight('generator_meta') }
+      hit[:version] = match[1] if match[1]
+      hit
+    end
+
+    def evaluate_html_substring(html, name)
+      html.include?(config[name]['pattern']) ? { weight: weight(name) } : nil
+    end
+
+    def evaluate_wp_json(uri)
+      response = http_get(build_url(uri, config['wp_json_rest']['path']))
+      return nil unless response&.success?
+
+      data = JSON.parse(response.body.to_s)
+      wordpress_like_json?(data) ? { weight: weight('wp_json_rest') } : nil
+    rescue JSON::ParserError
+      nil
+    end
+
+    def evaluate_body_contains(uri, name, needle)
+      response = http_get(build_url(uri, config[name]['path']))
+      return nil unless response&.status&.between?(200, 299)
+
+      body = response.body.to_s
+      matched = needle.is_a?(Regexp) ? body.match?(needle) : body.include?(needle)
+      matched ? { weight: weight(name) } : nil
+    end
+
+    def wordpress_like_json?(data)
+      return false unless data.is_a?(Hash)
+
+      namespaces = data['namespaces']
+      return true if namespaces.is_a?(Array) && namespaces.include?('wp/v2')
+
+      %w[name description url home].count { |k| data.key?(k) } >= 2
+    end
+
+    def fetch_body(url)
+      response = http_get(url)
+      response&.success? ? response.body.to_s : ''
+    end
+
+    def parse_uri(url)
+      URI.parse(url)
+    rescue URI::InvalidURIError
+      nil
+    end
+
+    def build_url(uri, path)
+      port_part = uri.port == uri.default_port ? '' : ":#{uri.port}"
+      "#{uri.scheme}://#{uri.host}#{port_part}#{path}"
+    end
+
+    def config
+      @config ||= YAML.safe_load_file(CONFIG_PATH).fetch('signatures')
+    end
+
+    def weight(name)
+      config.dig(name, 'weight').to_f
+    end
+  end
+end
+
+Fingerprinters::FingerprinterRegistry.register(Fingerprinters::WordpressFingerprinter)

--- a/config/fingerprints/wordpress/core.yml
+++ b/config/fingerprints/wordpress/core.yml
@@ -1,0 +1,19 @@
+signatures:
+  generator_meta:
+    weight: 0.7
+    pattern: '<meta[^>]+name=["\'']generator["\''][^>]+content=["\'']WordPress\s+([\d.]+)'
+  wp_content_path:
+    weight: 0.3
+    pattern: 'wp-content/'
+  wp_includes_path:
+    weight: 0.2
+    pattern: 'wp-includes/'
+  wp_json_rest:
+    weight: 0.5
+    path: '/wp-json/'
+  readme_html:
+    weight: 0.2
+    path: '/readme.html'
+  wp_login:
+    weight: 0.2
+    path: '/wp-login.php'

--- a/spec/integration/e2e_scan_pipeline_spec.rb
+++ b/spec/integration/e2e_scan_pipeline_spec.rb
@@ -43,6 +43,14 @@ RSpec.describe 'E2E Scan Pipeline', :integration do # rubocop:disable RSpec/Desc
                                                   headers: { 'Content-Type' => 'application/json' })
     stub_request(:get, /www.cisa.gov/).to_return(status: 200, body: '{"vulnerabilities":[]}',
                                                  headers: { 'Content-Type' => 'application/json' })
+
+    # Stub the fingerprinter registry to a deterministic result (detector integration
+    # is covered by fingerprinter specs, not the E2E pipeline).
+    registry = instance_double(
+      Fingerprinters::FingerprinterRegistry,
+      detect: { cms: 'unknown', confidence: 0.0, components: [], detected_at: Time.current.iso8601 }
+    )
+    allow(Fingerprinters::FingerprinterRegistry).to receive(:new).and_return(registry)
   end
 
   describe 'full pipeline: scan → normalize → export' do

--- a/spec/services/fingerprinters/wordpress_fingerprinter_spec.rb
+++ b/spec/services/fingerprinters/wordpress_fingerprinter_spec.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+
+require 'sequel_helper'
+
+RSpec.describe Fingerprinters::WordpressFingerprinter do
+  let(:target) { create(:target, urls: ['https://wp.example.com'].to_json) }
+  let(:scan) { create(:scan, target:) }
+  let(:detector) { described_class.new(scan) }
+  let(:threshold) { Fingerprinters::FingerprinterBase::MIN_CONFIDENCE }
+
+  let(:wp_html) do
+    <<~HTML
+      <!DOCTYPE html>
+      <html>
+        <head>
+          <meta name="generator" content="WordPress 6.4.2">
+          <link rel="stylesheet" href="/wp-content/themes/astra/style.css">
+          <script src="/wp-includes/js/jquery.js"></script>
+        </head>
+        <body>Hello</body>
+      </html>
+    HTML
+  end
+
+  let(:plain_html) { '<html><body>Just a plain page</body></html>' }
+
+  let(:wp_json_body) do
+    JSON.dump(
+      name: 'Test WP Site',
+      description: 'Just another WordPress site',
+      url: 'https://wp.example.com',
+      home: 'https://wp.example.com',
+      namespaces: %w[wp/v2 oembed/1.0]
+    )
+  end
+
+  before do
+    stub_request(:get, 'https://wp.example.com/wp-json/').to_return(status: 404)
+    stub_request(:get, 'https://wp.example.com/readme.html').to_return(status: 404)
+    stub_request(:get, 'https://wp.example.com/wp-login.php').to_return(status: 404)
+  end
+
+  describe '#cms_name' do
+    it 'returns wordpress' do
+      expect(detector.cms_name).to eq('wordpress')
+    end
+  end
+
+  describe '#detect' do
+    it 'detects WordPress with high confidence from generator meta and asset paths' do
+      stub_request(:get, 'https://wp.example.com').to_return(status: 200, body: wp_html)
+
+      result = detector.detect
+      expect(result[:cms]).to eq('wordpress')
+      expect(result[:confidence]).to be >= 0.8
+      expect(result[:core_version]).to eq('6.4.2')
+      expect(result[:components]).to eq([])
+    end
+
+    it 'returns sub-threshold confidence for a plain HTML page' do
+      stub_request(:get, 'https://wp.example.com').to_return(status: 200, body: plain_html)
+
+      result = detector.detect
+      expect(result[:cms]).to eq('wordpress')
+      expect(result[:confidence]).to be < threshold
+      expect(result[:core_version]).to be_nil
+    end
+
+    it 'detects WordPress via the REST API when the generator meta is stripped' do
+      stripped = wp_html.sub(/<meta[^>]*generator[^>]*>/, '')
+      stub_request(:get, 'https://wp.example.com').to_return(status: 200, body: stripped)
+      stub_request(:get, 'https://wp.example.com/wp-json/')
+        .to_return(status: 200, body: wp_json_body, headers: { 'Content-Type' => 'application/json' })
+
+      result = detector.detect
+      expect(result[:confidence]).to be >= threshold
+      expect(result[:core_version]).to be_nil
+    end
+
+    it 'adds weight for a readme.html page that contains WordPress' do
+      stub_request(:get, 'https://wp.example.com').to_return(status: 200, body: plain_html)
+      stub_request(:get, 'https://wp.example.com/readme.html')
+        .to_return(status: 200, body: '<html>WordPress 6.x docs</html>')
+
+      result = detector.detect
+      expect(result[:confidence]).to be > 0.0
+    end
+
+    it 'does not count readme.html when the body does not mention WordPress' do
+      stub_request(:get, 'https://wp.example.com').to_return(status: 200, body: plain_html)
+      stub_request(:get, 'https://wp.example.com/readme.html')
+        .to_return(status: 200, body: '<html>Random content</html>')
+
+      result = detector.detect
+      expect(result[:confidence]).to eq(0.0)
+    end
+
+    it 'handles an empty target URL list' do
+      allow(scan.target).to receive(:url_list).and_return([])
+      expect(detector.detect).to eq(cms: 'wordpress', confidence: 0.0, components: [])
+    end
+
+    it 'does not raise when the root page is unreachable' do
+      stub_request(:get, 'https://wp.example.com').to_raise(Faraday::ConnectionFailed.new('refused'))
+
+      expect { detector.detect }.not_to raise_error
+      expect(detector.detect[:confidence]).to eq(0.0)
+    end
+
+    it 'ignores malformed wp-json responses' do
+      stub_request(:get, 'https://wp.example.com').to_return(status: 200, body: plain_html)
+      stub_request(:get, 'https://wp.example.com/wp-json/')
+        .to_return(status: 200, body: 'not json at all')
+
+      result = detector.detect
+      expect(result[:confidence]).to eq(0.0)
+    end
+  end
+
+  describe 'registry registration' do
+    # Registry state may be reset by other specs — reload the detector file to re-trigger
+    # the module-level `FingerprinterRegistry.register(...)` call.
+    it 'registers itself with the FingerprinterRegistry at load time' do
+      Fingerprinters::FingerprinterRegistry.reset!
+      load Penetrator.root.join('app/services/fingerprinters/wordpress_fingerprinter.rb').to_s
+
+      expect(Fingerprinters::FingerprinterRegistry.detectors).to include(described_class)
+    end
+  end
+end

--- a/spec/services/scan_orchestrator_spec.rb
+++ b/spec/services/scan_orchestrator_spec.rb
@@ -17,6 +17,15 @@ RSpec.describe ScanOrchestrator do
     allow(ScanProfile).to receive(:load).and_return(mock_profile)
     allow(FindingNormalizer).to receive(:new).and_return(instance_double(FindingNormalizer, normalize: nil))
     stub_request(:head, 'https://example.com/').to_return(status: 200)
+    stub_default_fingerprinter_registry
+  end
+
+  def stub_default_fingerprinter_registry
+    registry = instance_double(
+      Fingerprinters::FingerprinterRegistry,
+      detect: { cms: 'unknown', confidence: 0.0, components: [], detected_at: Time.current.iso8601 }
+    )
+    allow(Fingerprinters::FingerprinterRegistry).to receive(:new).and_return(registry)
   end
 
   describe '#execute' do


### PR DESCRIPTION
## Summary

Second deliverable under epic #736. Lands the WordPress CMS-level detector:
- `Fingerprinters::WordpressFingerprinter` — weighted signature scorer with 6 signals (generator meta, `wp-content/`, `wp-includes/`, `/wp-json/`, `/readme.html`, `/wp-login.php`)
- `config/fingerprints/wordpress/core.yml` — signatures externalised for review-friendly updates without Ruby changes
- Auto-registers with `FingerprinterRegistry` at load time (runs ahead of `GenericFingerprinter`)
- Core version extracted from `<meta generator>` when present

## Spec hygiene

- Orchestrator spec + E2E spec now stub `FingerprinterRegistry` so no detector HTTP calls leak into those specs (detector integration is covered by the WP detector spec). This fixed 16 pre-existing specs that would otherwise see `WebMock::NetConnectNotAllowedError` (WebMock inherits this from `Exception`, not `StandardError`).
- WP detector spec has 10 examples: high-confidence detection, sub-threshold plain HTML, REST-API-only path, readme.html weight, malformed JSON, unreachable host, empty URL list, registration.

## Test plan
- [x] `bundle exec rspec` — 565 examples, 0 failures, 94.05% line coverage
- [x] `bundle exec rubocop` on touched files — no offences
- [x] Pre-commit green

## Not in this PR
- Plugin/theme enumeration (#739, blocked by cve-watch#2 signature-generation utility)
- Schema version bump + envelope key (#740)
- Opt-in Nuclei auto-templates (#741)

Part of epic #736.