### PR TITLE
feat: emit cms_inventory in scan envelope + bump SCHEMA_VERSION to 1.3 (#740)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- feat: emit cms_inventory in scan envelope + bump SCHEMA_VERSION to 1.3 (#740)
 - feat: fingerprinter framework (base class, registry, generic fallback) + orchestrator hook writes `cms_inventory` into `scan.summary` (#737)
 - fix: callback URL path doubled — `/callbacks/callbacks/heartbeat` — treat CALLBACK_URL as base, append only endpoint suffix; fix vm-startup.sh auth header (#728) 
 - fix: scan VMs preempted immediately — SPOT pricing now opt-in, defaults to on-demand for reliability (#719)

--- a/app/services/scan_results_exporter.rb
+++ b/app/services/scan_results_exporter.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ScanResultsExporter
-  SCHEMA_VERSION = '1.2'
+  SCHEMA_VERSION = '1.3'
 
   def initialize(scan, cost_logger: nil)
     @scan = scan
@@ -103,7 +103,8 @@ class ScanResultsExporter
       by_severity: summary['by_severity'] || @findings.group_and_count(:severity).all.to_h { |r| [r[:severity], r[:count]] },
       tools_run: summary['tools_run'] || (@scan.tool_statuses || {}).keys,
       duration_seconds: summary['duration_seconds'] || @scan.duration&.to_i,
-      executive_summary: summary['executive_summary']
+      executive_summary: summary['executive_summary'],
+      cms_inventory: summary['cms_inventory']
     }
   end
 

--- a/spec/integration/e2e_scan_pipeline_spec.rb
+++ b/spec/integration/e2e_scan_pipeline_spec.rb
@@ -76,14 +76,14 @@ RSpec.describe 'E2E Scan Pipeline', :integration do # rubocop:disable RSpec/Desc
       expect(summary['by_severity']).to be_a(Hash)
     end
 
-    it 'exports a v1.1 JSON envelope' do
+    it 'exports a v1.3 JSON envelope' do
       orchestrator = ScanOrchestrator.new(scan)
       orchestrator.execute
 
       exporter = ScanResultsExporter.new(scan)
       envelope = exporter.build_envelope
 
-      expect(envelope[:schema_version]).to eq('1.2')
+      expect(envelope[:schema_version]).to eq('1.3')
       expect(envelope[:metadata][:scan_id]).to eq(scan.id)
       expect(envelope[:metadata][:target_name]).to eq('DVWA E2E Test')
       expect(envelope[:findings]).to be_an(Array)

--- a/spec/services/audit_logger_spec.rb
+++ b/spec/services/audit_logger_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe AuditLogger do
 
       expect(Penetrator.logger).to have_received(:info) do |msg|
         parsed = JSON.parse(msg)
-        expect(parsed['schema_version']).to eq('1.2')
+        expect(parsed['schema_version']).to eq('1.3')
       end
     end
   end

--- a/spec/services/big_query_logger_spec.rb
+++ b/spec/services/big_query_logger_spec.rb
@@ -195,7 +195,7 @@ RSpec.describe BigQueryLogger do
         row = rows.first
         expect(row[:fingerprint]).to eq(finding.fingerprint)
         expect(row[:severity]).to eq('high')
-        expect(row[:schema_version]).to eq('1.2')
+        expect(row[:schema_version]).to eq('1.3')
         expect(row[:cve_id]).to eq('CVE-2024-5678')
         expect(row[:cvss_score]).to eq(7.5)
         expect(row[:parameter]).to eq('q')

--- a/spec/services/scan_results_exporter_spec.rb
+++ b/spec/services/scan_results_exporter_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe ScanResultsExporter do
     let(:envelope) { exporter.build_envelope }
 
     it 'includes schema_version' do
-      expect(envelope[:schema_version]).to eq('1.2')
+      expect(envelope[:schema_version]).to eq('1.3')
     end
 
     describe 'tool_chain' do
@@ -144,6 +144,24 @@ RSpec.describe ScanResultsExporter do
       it 'includes executive summary' do
         expect(summary[:executive_summary]).to eq('Two vulnerabilities identified.')
       end
+
+      context 'with cms_inventory on the scan' do
+        let(:inventory) { { 'cms' => 'wordpress', 'confidence' => 0.85, 'components' => [], 'core_version' => '6.4.2' } }
+
+        before do
+          scan.summary = scan.summary.merge('cms_inventory' => inventory)
+          scan.save_changes
+        end
+
+        it 'surfaces cms_inventory in the envelope summary' do
+          expect(exporter.build_envelope[:summary][:cms_inventory]).to eq(inventory)
+        end
+      end
+
+      it 'returns nil cms_inventory when none was captured' do
+        expect(summary).to have_key(:cms_inventory)
+        expect(summary[:cms_inventory]).to be_nil
+      end
     end
 
     describe 'findings' do
@@ -202,7 +220,7 @@ RSpec.describe ScanResultsExporter do
       allow(storage_service).to receive(:upload) do |local_path, _remote, **_opts|
         content = File.read(local_path)
         parsed = JSON.parse(content)
-        expect(parsed['schema_version']).to eq('1.2')
+        expect(parsed['schema_version']).to eq('1.3')
         expect(parsed['findings'].size).to eq(2)
         true
       end

--- a/spec/smoke/library_integrations_spec.rb
+++ b/spec/smoke/library_integrations_spec.rb
@@ -337,9 +337,9 @@ RSpec.describe 'Library integration smoke tests', :smoke do # rubocop:disable RS
                        epss_score: 0.5, kev_known_exploited: false, duplicate: false)
     end
 
-    it 'uses schema version 1.2' do
+    it 'uses schema version 1.3' do
       envelope = ScanResultsExporter.new(export_scan).build_envelope
-      expect(envelope[:schema_version]).to eq('1.2')
+      expect(envelope[:schema_version]).to eq('1.3')
     end
 
     it 'includes CVSS/EPSS/KEV enrichment fields in findings' do


### PR DESCRIPTION
## Summary

Third deliverable under epic #736. Surfaces CMS inventory in the GCS scan-results envelope:
- `SCHEMA_VERSION` bumped `1.2` → `1.3`
- `build_summary` now includes `cms_inventory: summary['cms_inventory']` — may be `nil` for scans that skipped fingerprinting or predate the feature
- Reporter payload unchanged — `ScanCallbackService` already forwards `summary` in full, so inventory rides along automatically

## Spec updates
Schema-version assertions bumped to `1.3` across: exporter, audit_logger, big_query_logger, e2e_scan_pipeline, smoke/library_integrations. New exporter specs assert `cms_inventory` presence and nil-safety.

## Test plan
- [x] `bundle exec rspec` — 557 examples, 0 failures, 93.83% line coverage
- [x] `bundle exec rubocop` — no offences on touched files
- [x] Pre-commit green

## Not in this PR
- WordPress detector (#738, separate PR #745 — independent)
- Plugin/theme enumeration (#739, blocked by cve-watch#2)
- Opt-in Nuclei auto-templates (#741)

Part of epic #736.