### PR TITLE
feat: opt-in Nuclei auto-templates when WordPress detected (#741)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- feat: opt-in Nuclei auto-templates when WordPress is detected — default off, enable per-profile with `auto_templates: true` on the nuclei tool config (#741)
 - feat: WordPress CMS detector — generator meta + wp-content/wp-includes + wp-json REST + readme/wp-login probes with weighted confidence scoring and core-version extraction (#738)
 - feat: fingerprinter framework (base class, registry, generic fallback) + orchestrator hook writes `cms_inventory` into `scan.summary` (#737)
 - fix: callback URL path doubled — `/callbacks/callbacks/heartbeat` — treat CALLBACK_URL as base, append only endpoint suffix; fix vm-startup.sh auth header (#728) 

--- a/app/services/scanners/nuclei_scanner.rb
+++ b/app/services/scanners/nuclei_scanner.rb
@@ -1,5 +1,9 @@
 module Scanners
   class NucleiScanner < ScannerBase
+    CMS_TEMPLATE_PATHS = {
+      'wordpress' => %w[http/technologies/wordpress/ http/cves/wordpress/ http/vulnerabilities/wordpress/]
+    }.freeze
+
     def tool_name
       'nuclei'
     end
@@ -26,12 +30,25 @@ module Scanners
 
       cmd += " -severity #{tool_config[:severity_filter]}" if tool_config[:severity_filter]
 
-      tool_config[:templates].each { |t| cmd += " -t #{Shellwords.escape(t)}" } if tool_config[:templates].present?
+      templates = combined_templates
+      templates.each { |t| cmd += " -t #{Shellwords.escape(t)}" } if templates.any?
 
       cmd += " -rate-limit #{tool_config[:rate_limit]}" if tool_config[:rate_limit]
       cmd += " -bulk-size #{tool_config[:bulk_size]}" if tool_config[:bulk_size]
 
       cmd
+    end
+
+    def combined_templates
+      explicit = Array(tool_config[:templates])
+      (explicit + auto_templates).uniq
+    end
+
+    def auto_templates
+      return [] unless tool_config[:auto_templates]
+
+      detected_cms = scan.summary&.dig('cms_inventory', 'cms')
+      CMS_TEMPLATE_PATHS.fetch(detected_cms, [])
     end
 
     def parse_results(output_file)

--- a/spec/services/scanners/nuclei_scanner_spec.rb
+++ b/spec/services/scanners/nuclei_scanner_spec.rb
@@ -82,5 +82,73 @@ RSpec.describe Scanners::NucleiScanner do
       result = scanner.run
       expect(result[:success]).to be true
     end
+
+    context 'with auto_templates enabled and WordPress detected' do
+      let(:tool_config) { { auto_templates: true, timeout: 600 } }
+
+      before do
+        scan.summary = { 'cms_inventory' => { 'cms' => 'wordpress', 'confidence' => 0.9 } }
+        scan.save_changes
+      end
+
+      it 'appends WordPress-specific Nuclei template paths' do
+        expect(scanner).to receive(:run_command) do |cmd, **_opts|
+          expect(cmd).to include('-t http/technologies/wordpress/')
+          expect(cmd).to include('-t http/cves/wordpress/')
+          success_result
+        end
+
+        scanner.run
+      end
+
+      it 'merges auto templates with explicit templates without duplicates' do
+        scanner = described_class.new(scan, auto_templates: true,
+                                            templates: ['http/technologies/wordpress/', '/custom/t.yaml'],
+                                            timeout: 600)
+        allow(scanner).to receive(:run_command).and_return(success_result)
+        allow(ResultParsers::NucleiParser).to receive(:new).and_return(
+          instance_double(ResultParsers::NucleiParser, parse: [])
+        )
+
+        expect(scanner).to receive(:run_command) do |cmd, **_opts|
+          expect(cmd.scan('-t http/technologies/wordpress/').size).to eq(1)
+          expect(cmd).to include('-t /custom/t.yaml')
+          success_result
+        end
+
+        scanner.run
+      end
+    end
+
+    context 'with auto_templates enabled but no WordPress detected' do
+      let(:tool_config) { { auto_templates: true, timeout: 600 } }
+
+      it 'does not append any CMS template paths' do
+        expect(scanner).to receive(:run_command) do |cmd, **_opts|
+          expect(cmd).not_to include('-t http/technologies/wordpress/')
+          success_result
+        end
+
+        scanner.run
+      end
+    end
+
+    context 'with auto_templates disabled (default) and WordPress detected' do
+      let(:tool_config) { { timeout: 600 } }
+
+      before do
+        scan.summary = { 'cms_inventory' => { 'cms' => 'wordpress', 'confidence' => 0.9 } }
+        scan.save_changes
+      end
+
+      it 'does not append CMS template paths' do
+        expect(scanner).to receive(:run_command) do |cmd, **_opts|
+          expect(cmd).not_to include('-t http/')
+          success_result
+        end
+
+        scanner.run
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

Fourth deliverable under epic #736. Wires the fingerprinter output into Nuclei:
- New `CMS_TEMPLATE_PATHS` mapping in `NucleiScanner` (initially just WordPress: `http/technologies/wordpress/`, `http/cves/wordpress/`, `http/vulnerabilities/wordpress/`)
- When `tool_config[:auto_templates]` is true AND `scan.summary.cms_inventory.cms` matches a known key, append those paths to the `-t` flags (de-duplicated with explicit templates)
- **Default off** on every profile — explicit per-profile opt-in required. `thorough`/`deep` unchanged.

## Spec coverage (4 new examples)
- WordPress detected + flag on → WP template paths appended
- Explicit + auto templates merge with no duplicates
- Flag on but no WP detected → no CMS paths
- Flag off (default) even with WP detected → no CMS paths

## Test plan
- [x] `bundle exec rspec` — 569 examples, 0 failures, 94.08% coverage
- [x] `bundle exec rubocop` — no offences on touched files
- [x] Pre-commit green

## Wave 1 status after this PR
- ✅ #737 Framework (merged)
- ✅ #738 WordPress detector (merged)
- 🟡 #740 Envelope key + SCHEMA 1.3 (PR #747 open)
- 🟡 #741 Nuclei auto-templates (this PR)
- ⏸ #739 Plugin/theme enumeration — blocked by cve-watch#2 signature generator

Part of epic #736.