### PR TITLE
fix: version-bump.sh re-seeds Unreleased + creates GitHub Release per tag (#753)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,25 +2,15 @@
 
 ## Unreleased
 
+- fix: version-bump.sh re-seeds `## Unreleased` and creates a GitHub Release per tag — previously orphan tags accumulated and Unreleased items piled under older versions; historical v0.16.2/4/6/7 still empty pending manual backfill (#753)
+
 ## v0.17.0 — 2026-04-19
 
-## v0.16.6 — 2026-04-09
-
-
-## v0.16.4 — 2026-04-09
-
-
-## v0.16.2 — 2026-04-06
-
-
-## v0.16.0 — 2026-04-06
-
-- fix: heartbeat stops updating during long Nuclei scans — cache StorageService, isolate tick operations with independent timeouts (#661)
 - feat: opt-in Nuclei auto-templates when WordPress is detected — default off, enable per-profile with `auto_templates: true` on the nuclei tool config (#741)
 - feat: emit cms_inventory in scan envelope + bump SCHEMA_VERSION to 1.3 (#740)
 - feat: WordPress CMS detector — generator meta + wp-content/wp-includes + wp-json REST + readme/wp-login probes with weighted confidence scoring and core-version extraction (#738)
 - feat: fingerprinter framework (base class, registry, generic fallback) + orchestrator hook writes `cms_inventory` into `scan.summary` (#737)
-- fix: callback URL path doubled — `/callbacks/callbacks/heartbeat` — treat CALLBACK_URL as base, append only endpoint suffix; fix vm-startup.sh auth header (#728) 
+- fix: callback URL path doubled — `/callbacks/callbacks/heartbeat` — treat CALLBACK_URL as base, append only endpoint suffix; fix vm-startup.sh auth header (#728)
 - fix: scan VMs preempted immediately — SPOT pricing now opt-in, defaults to on-demand for reliability (#719)
 - fix: CI workflow runs on on-demand VMs to avoid spot preemption (#726)
 - fix: scan VMs fail on zone exhaustion — on-demand only, multi-region zone fallback (9 zones), structured 503 on total failure (#710, #719)
@@ -30,6 +20,22 @@
 - fix: sync-back PRs no longer block unrelated promotions — guard scoped to target base branch (#698)
 - fix: make callback_url a required parameter from trigger call — reject with 400 if missing (#695)
 - fix: promote workflow must depends_on deploy to prevent pipeline contention (#691)
+
+## v0.16.6 — 2026-04-09
+
+_Empty — release notes were eaten by the version-bump bug fixed in #753. Backfill pending._
+
+## v0.16.4 — 2026-04-09
+
+_Empty — release notes were eaten by the version-bump bug fixed in #753. Backfill pending._
+
+## v0.16.2 — 2026-04-06
+
+_Empty — release notes were eaten by the version-bump bug fixed in #753. Backfill pending._
+
+## v0.16.0 — 2026-04-06
+
+- fix: heartbeat stops updating during long Nuclei scans — cache StorageService, isolate tick operations with independent timeouts (#661)
 
 ## v0.15.2 — 2026-04-05
 

--- a/scripts/woodpecker/version-bump.sh
+++ b/scripts/woodpecker/version-bump.sh
@@ -7,9 +7,11 @@ set -euo pipefail
 #    - feat: → minor
 #    - everything else → patch
 # 2. Increment VERSION
-# 3. Update RELEASE_NOTES — move Unreleased items under version header
+# 3. Update RELEASE_NOTES — rename ## Unreleased to ## vX.Y.Z, re-seed a fresh
+#    ## Unreleased above so future PRs have a target section
 # 4. Commit + tag
-# 5. Tag Docker image (scanner:staging → scanner:vX.Y.Z + scanner:production)
+# 5. Create GitHub Release with the notes body (every tag gets a Release)
+# 6. Tag Docker image (scanner:staging → scanner:vX.Y.Z + scanner:production)
 
 REPO="Peregrine-Technology-Systems/peregrine-penetrator-scanner"
 API="https://api.github.com"
@@ -97,14 +99,29 @@ fi
 echo "${NEW_VERSION}" > VERSION
 echo "VERSION: ${CURRENT} → ${NEW_VERSION}"
 
-# Update RELEASE_NOTES.md — replace ## Unreleased with ## vX.Y.Z — date
+# Update RELEASE_NOTES.md — rename current ## Unreleased to ## vX.Y.Z, and insert
+# a fresh empty ## Unreleased above so future PRs have a target section.
+# Without the fresh Unreleased re-seed, subsequent PRs add items with no section
+# header, and the next bump renames an already-empty section (issue #753).
 DATE=$(date +%Y-%m-%d)
-if grep -q '^## Unreleased' RELEASE_NOTES.md; then
-  sed -i "s/^## Unreleased$/## ${TAG} — ${DATE}/" RELEASE_NOTES.md
-  echo "RELEASE_NOTES: ## Unreleased → ## ${TAG} — ${DATE}"
+if grep -q '^## Unreleased$' RELEASE_NOTES.md; then
+  # GNU sed: \n in replacement works on Linux (CI runs on Linux).
+  sed -i "s/^## Unreleased\$/## Unreleased\n\n## ${TAG} — ${DATE}/" RELEASE_NOTES.md
+  echo "RELEASE_NOTES: renamed ## Unreleased → ## ${TAG} — ${DATE}, seeded fresh ## Unreleased"
 else
-  echo "WARNING: No ## Unreleased section found in RELEASE_NOTES.md"
+  # No Unreleased heading — insert both fresh Unreleased and the new version
+  # heading right after the top-level title. This self-heals repos where
+  # version-bump previously consumed the Unreleased heading without re-seeding.
+  sed -i "1,/^# Release Notes/{s|^# Release Notes\$|# Release Notes\n\n## Unreleased\n\n## ${TAG} — ${DATE}|}" RELEASE_NOTES.md
+  echo "RELEASE_NOTES: no Unreleased section found — self-healed, added fresh ## Unreleased + ## ${TAG}"
 fi
+
+# Extract release notes content for the new version (between ## vX.Y.Z and the next ## heading)
+RELEASE_BODY=$(awk -v tag="## ${TAG} — ${DATE}" '
+  $0 == tag { capture = 1; next }
+  capture && /^## / { exit }
+  capture { print }
+' RELEASE_NOTES.md)
 
 # Commit all version changes
 git config user.name "woodpecker-ci[bot]"
@@ -125,6 +142,26 @@ git push origin main
 git tag -a "${TAG}" -m "Release ${TAG}"
 git push origin "${TAG}"
 echo "Created and pushed tag: ${TAG}"
+
+# Create GitHub Release — every tag must have a corresponding Release (no orphan tags).
+# Body is the RELEASE_NOTES section extracted above.
+RELEASE_PAYLOAD=$(jq -n \
+  --arg tag "${TAG}" \
+  --arg name "${TAG}" \
+  --arg body "${RELEASE_BODY:-No release notes captured.}" \
+  '{tag_name: $tag, name: $name, body: $body, draft: false, prerelease: false}')
+
+RELEASE_RESPONSE=$(curl -s -o /tmp/release-response.json -w "%{http_code}" \
+  -X POST -H "$AUTH" -H "Accept: application/vnd.github+json" \
+  "${API}/repos/${REPO}/releases" \
+  -d "${RELEASE_PAYLOAD}")
+
+if [ "$RELEASE_RESPONSE" = "201" ]; then
+  echo "Created GitHub Release: ${TAG}"
+else
+  echo "WARNING: Failed to create GitHub Release (HTTP ${RELEASE_RESPONSE})"
+  cat /tmp/release-response.json
+fi
 
 # Tag Docker image by DIGEST: scanner:staging → scanner:vX.Y.Z + scanner:production
 # Using digest ensures the exact bytes that passed staging CI get promoted,


### PR DESCRIPTION
## Summary

Closes #753 (primary fix; historical backfill of v0.16.2/4/6 still pending).

**Two bugs in version-bump.sh:**
1. sed renamed \`## Unreleased\` → \`## vX.Y.Z\` but didn't insert a fresh \`## Unreleased\` above, so subsequent PRs had no target heading — items piled under older versions.
2. The script never called the Releases API. Only v0.1.0 had a corresponding GitHub Release; every tag since was orphaned despite MUST HAVE rule #8.

**Fixes:**
- sed replacement now emits both a fresh \`## Unreleased\` and the new \`## vX.Y.Z\` heading.
- Self-heal: if no \`## Unreleased\` exists, insert both headings right after the \`# Release Notes\` title.
- Extract release body via awk between \`## vX.Y.Z\` and next \`## \` heading.
- POST to \`/repos/:repo/releases\` with tag + body so every tag gets a Release.

**Also backfilled RELEASE_NOTES:**
- Moved Wave 1 items (#737, #738, #740, #741) and prior session's fixes (#728, #719, #726, #710, #711, #691, #697, #698, #695) from under the stale v0.16.0 heading to v0.17.0 where they actually shipped.
- v0.16.2/4/6 still marked "empty — backfill pending" (reconstruction from git log is follow-up work).

## Test plan
- [x] Dry-run sed + awk logic locally with synthetic RELEASE_NOTES — produces expected structure on both the normal path (has Unreleased) and self-heal path (no Unreleased).
- [x] Pre-commit green (91.79% coverage, no Ruby changes so RSpec unchanged).
- [x] Next version bump will validate end-to-end; script idempotency guards already prevent re-tag loops.

Part of #753.