### PR TITLE
docs: backfill RELEASE_NOTES for v0.16.1-v0.16.7 from git log (#753)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- fix: version-bump.sh re-seeds `## Unreleased` and creates a GitHub Release per tag — previously orphan tags accumulated and Unreleased items piled under older versions; historical v0.16.2/4/6/7 still empty pending manual backfill (#753)
+- fix: version-bump.sh re-seeds `## Unreleased` and creates a GitHub Release per tag — previously orphan tags accumulated and Unreleased items piled under older versions. Historical v0.16.1–v0.16.7 backfilled from git log in the same PR (#753)
 
 ## v0.17.0 — 2026-04-19
 
@@ -10,32 +10,44 @@
 - feat: emit cms_inventory in scan envelope + bump SCHEMA_VERSION to 1.3 (#740)
 - feat: WordPress CMS detector — generator meta + wp-content/wp-includes + wp-json REST + readme/wp-login probes with weighted confidence scoring and core-version extraction (#738)
 - feat: fingerprinter framework (base class, registry, generic fallback) + orchestrator hook writes `cms_inventory` into `scan.summary` (#737)
+
+## v0.16.7 — 2026-04-12
+
 - fix: callback URL path doubled — `/callbacks/callbacks/heartbeat` — treat CALLBACK_URL as base, append only endpoint suffix; fix vm-startup.sh auth header (#728)
-- fix: scan VMs preempted immediately — SPOT pricing now opt-in, defaults to on-demand for reliability (#719)
 - fix: CI workflow runs on on-demand VMs to avoid spot preemption (#726)
-- fix: scan VMs fail on zone exhaustion — on-demand only, multi-region zone fallback (9 zones), structured 503 on total failure (#710, #719)
-- fix: VM startup failure observability — Cloud Function writes vm-created marker to GCS, EXIT trap sends failure callback to orchestrator (#711)
-- fix: revert promote depends_on deploy — deploy only runs on staging, blocking dev→staging promotion (#691)
-- fix: heartbeat stops updating during long Nuclei scans — chunked stdout reading yields GIL to heartbeat thread (#697)
-- fix: sync-back PRs no longer block unrelated promotions — guard scoped to target base branch (#698)
-- fix: make callback_url a required parameter from trigger call — reject with 400 if missing (#695)
-- fix: promote workflow must depends_on deploy to prevent pipeline contention (#691)
+- fix: scan VMs fail on zone exhaustion — multi-region zone fallback (9 zones), structured 503 on total failure (#710)
 
 ## v0.16.6 — 2026-04-09
 
-_Empty — release notes were eaten by the version-bump bug fixed in #753. Backfill pending._
+- fix: scan VMs preempted immediately — SPOT pricing now opt-in, defaults to on-demand for reliability (#719)
+
+## v0.16.5 — 2026-04-09
+
+- fix: VM startup failure observability — Cloud Function writes vm-created marker to GCS, EXIT trap sends failure callback to orchestrator (#711)
+- fix: revert promote depends_on deploy — deploy only runs on staging, was blocking dev→staging promotion (#691)
 
 ## v0.16.4 — 2026-04-09
 
-_Empty — release notes were eaten by the version-bump bug fixed in #753. Backfill pending._
+- fix: heartbeat stops updating during long Nuclei scans — chunked stdout reading yields GIL to heartbeat thread (#697)
+- fix: sync-back PRs no longer block unrelated promotions — guard scoped to target base branch (#698)
+
+## v0.16.3 — 2026-04-09
+
+- fix: make callback_url a required parameter from trigger call — reject with 400 if missing (#695, #691)
+- fix: pre-commit hook excludes spec/ from code files — lint was being skipped (#683, #690)
 
 ## v0.16.2 — 2026-04-06
 
-_Empty — release notes were eaten by the version-bump bug fixed in #753. Backfill pending._
+- fix: BQ cost insert fails silently on schema mismatch — schema integrity smoke tests added (#661, #651)
+
+## v0.16.1 — 2026-04-06
+
+- fix: heartbeat stops updating during long Nuclei scans — cache StorageService, isolate tick operations with independent timeouts (#661)
 
 ## v0.16.0 — 2026-04-06
 
-- fix: heartbeat stops updating during long Nuclei scans — cache StorageService, isolate tick operations with independent timeouts (#661)
+- feat: tool chain in GCS export and callback payload — planned tools, per-tool timing, exit codes, findings count; schema v1.2 (#663)
+- refactor: reduce redundant object instantiation and code duplication across services (#653)
 
 ## v0.15.2 — 2026-04-05
 


### PR DESCRIPTION
## Summary

Follow-up to PR #754 (merged). Completes the historical RELEASE_NOTES backfill for all orphan versions.

Source of truth: \`git log --pretty=format:'%s' v0.16.X..v0.16.Y\` filtered to conventional-commit subjects.

| Tag | Date | Items reconstructed |
|---|---|---|
| v0.16.0 | 2026-04-06 | #663 tool chain + schema v1.2, #653 refactor |
| v0.16.1 | 2026-04-06 | #661 heartbeat StorageService cache |
| v0.16.2 | 2026-04-06 | #661/#651 BQ cost schema |
| v0.16.3 | 2026-04-09 | #695 callback_url required, #683/#690 pre-commit |
| v0.16.4 | 2026-04-09 | #697 chunked stdout, #698 sync-back guard |
| v0.16.5 | 2026-04-09 | #711 VM observability, #691 revert promote depends_on |
| v0.16.6 | 2026-04-09 | #719 SPOT opt-in |
| v0.16.7 | 2026-04-12 | #728 callback URL, #726 CI on-demand, #710 zone fallback |

GitHub Releases for all 7 orphan tags already created via the API in the same session — verified at https://github.com/Peregrine-Technology-Systems/peregrine-penetrator-scanner/releases.

## Test plan

Docs-only commit — no code changes, no tests needed. Pre-commit confirmed docs-only path (\`📝 Docs-only commit — skipping tests and coverage\`). version-bump.sh will skip this on main merge per its existing \`^docs:\` guard.

Closes #753.