### PR TITLE
ci: remove failure: ignore from smoke-test step (#762)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -67,7 +67,7 @@ fi
 # ============================================================
 CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
 if [ "$CURRENT_BRANCH" != "development" ] && [ "$CURRENT_BRANCH" != "staging" ] && [ "$CURRENT_BRANCH" != "main" ]; then
-  CHANGED_MD=$(git diff --cached --name-only --diff-filter=ACM | grep '\.md$' | grep -v 'CLAUDE.md' | grep -v '.github/' || true)
+  CHANGED_MD=$(git diff --cached --name-only --diff-filter=ACM | grep '\.md$' | grep -v 'CLAUDE.md' | grep -v 'RELEASE_NOTES.md' | grep -v '.github/' || true)
   if [ -n "$CHANGED_MD" ]; then
     DOC_SCRIPT="scripts/docs/generate-doc-pdf.sh"
     if [ -x "$DOC_SCRIPT" ]; then

--- a/.woodpecker/smoke-test.yaml
+++ b/.woodpecker/smoke-test.yaml
@@ -23,7 +23,6 @@ steps:
         from_secret: notification_email
     commands:
       - scripts/woodpecker/smoke-test.sh
-    failure: ignore
 
   - name: cleanup-smoke-vms
     image: bash

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- ci: remove `failure: ignore` from smoke-test step — smoke-test failures no longer mask as pipeline success. `cleanup-smoke-vms` still runs via `when.status` so VMs get cleaned up even on failure (#762)
+
 ## v0.17.1 — 2026-04-20
 
 - fix: version-bump.sh re-seeds `## Unreleased` and creates a GitHub Release per tag — previously orphan tags accumulated and Unreleased items piled under older versions. Historical v0.16.1–v0.16.7 backfilled from git log in the same PR (#753)


### PR DESCRIPTION
Closes #762. Part of fleet-wide rollout — ci-infrastructure#1078.

Removes phantom success when smoke-test fails. cleanup-smoke-vms already has when.status — VMs still cleaned up on failure.

Bundled fix: excludes RELEASE_NOTES.md from pre-commit PDF generation (it changes every commit, pointless to regenerate, was hanging puppeteer locally).