### PR TITLE
fix: promote.sh delete stale remote merge branch before push (ci-infrastructure#1089)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix: `promote.sh` deletes stale remote merge branch before push — avoids non-fast-forward on close-and-retry (ci-infrastructure#1089)
+
 - ci: remove `failure: ignore` from smoke-test step — smoke-test failures no longer mask as pipeline success. `cleanup-smoke-vms` still runs via `when.status` so VMs get cleaned up even on failure (#762)
 
 ## v0.17.1 — 2026-04-20

--- a/scripts/woodpecker/promote.sh
+++ b/scripts/woodpecker/promote.sh
@@ -80,6 +80,11 @@ git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${REPO}
 
 git fetch --unshallow origin 2>/dev/null || true
 git fetch origin "$BRANCH" "$BASE"
+# Delete stale remote merge branch if one was left behind by a manually-closed
+# prior promote PR — otherwise the push below fails non-fast-forward.
+# (Incident 2026-04-21 across scaler/front-end/etc.)
+git push origin --delete "$MERGE_BRANCH" 2>/dev/null || true
+
 git checkout -b "$MERGE_BRANCH" "origin/${BASE}"
 
 if git merge "origin/${BRANCH}" --no-edit 2>/dev/null; then


### PR DESCRIPTION
## Summary

Adds `git push origin --delete "$MERGE_BRANCH" 2>/dev/null || true` before `git checkout -b "$MERGE_BRANCH"` in `scripts/woodpecker/promote.sh`.

Avoids non-fast-forward push failures when a prior promote PR was closed manually (revert cascade, branch-protection rejection, manual housekeeping) and left the remote merge branch behind pointing at old commits. Next promote then can't push the fresh merge branch.

Incident 2026-04-21: several repos including `peregrine-ci-scaler#484` hit this; manual recovery required (close stale PR, `git push origin --delete`, restart pipeline).

Fix is mechanical — one `delete-or-noop` before the push. No force-push, no branch-protection violation. No test suite needed.

## Reference implementations

- `peregrine-penetrator-sight` (merged)
- `peregrine-ci-scaler#491` (merged, commit ad9798d)

## Tracking

Tracked centrally at `peregrine-ci-infrastructure#1089`.

## Test plan

- [x] `bash -n scripts/woodpecker/promote.sh` passes (pre-commit hook)
- [x] CI passes on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)