### PR TITLE
feat: decouple production deploy from merge — GitHub Deployment API (#767)

### DIFF
--- a/.woodpecker/release.yaml
+++ b/.woodpecker/release.yaml
@@ -1,7 +1,10 @@
 # Production release: tag staging image as production (no build, no CI)
+#
+# #767: trigger flipped from `event: push, branch: main` to `event: deployment`
+# (cross-repo rollout #1187). version-bump.sh POSTs the GitHub Deployment API
+# after tag creation; the deployment webhook fires this pipeline.
 when:
-  - event: push
-    branch: main
+  - event: deployment
 
 labels:
   platform: linux
@@ -13,6 +16,8 @@ steps:
     environment:
       DOCKER_REGISTRY:
         from_secret: docker_registry
+      GH_TOKEN:
+        from_secret: gh_token
     commands:
       - scripts/woodpecker/deploy.sh
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,10 @@ Security scanning engine built with Ruby + Sequel ORM. Orchestrates open-source 
 
 Report generation, AI analysis, ticketing, and email notifications have been extracted to the [reporter](https://github.com/Peregrine-Technology-Systems/peregrine-penetrator-reporter) and backend services.
 
+## Deploy Trigger Pattern
+
+Production deploy is **decoupled** from main-branch push via the GitHub Deployment API per cross-repo rollout peregrine-ci-infrastructure#1187 (this repo's adoption: #767). Production lives in `.woodpecker/release.yaml` (NOT `deploy.yaml` — that's staging). After main merge: `version-bump.yaml` runs → tag + Release → `version-bump.sh` POSTs `/repos/.../deployments` → GitHub deployment webhook → `release.yaml` fires on `event=deployment` → `deploy.sh` (TARGET=main path) promotes scanner:staging digest to scanner:production + posts in_progress/success/failure status callbacks. Staging deploy still triggers on `event: push, branch: staging`.
+
 ## Build & Run Commands
 
 - Install deps: `bundle install`

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- feat: decouple production deploy from merge — fire GitHub Deployment API as a separate step (#767, cross-repo rollout #1187). `.woodpecker/release.yaml`'s production trigger flipped from `event: push, branch: main` to `event: deployment`. Staging deploy (`.woodpecker/deploy.yaml`) unchanged. `version-bump.sh` POSTs to `/repos/.../deployments` after Release creation; `deploy.sh` updated to map `CI_PIPELINE_EVENT == deployment` to TARGET=main and posts `in_progress` / `success` / `failure` status callbacks against the Deployment record. `GH_TOKEN` added to release.yaml's promote-image step. Reference impl: peregrine-grafana@f7507b4 + peregrine-monitoring@c80e0d3 + peregrine-penetrator-front-end PR#677. Allowlist prerequisite (ci-infrastructure#1188) cleared 2026-04-26.
+
 - fix: `promote.sh` deletes stale remote merge branch before push — avoids non-fast-forward on close-and-retry (ci-infrastructure#1089)
 
 - ci: remove `failure: ignore` from smoke-test step — smoke-test failures no longer mask as pipeline success. `cleanup-smoke-vms` still runs via `when.status` so VMs get cleaned up even on failure (#762)

--- a/scripts/woodpecker/deploy.sh
+++ b/scripts/woodpecker/deploy.sh
@@ -6,10 +6,53 @@ set -euo pipefail
 #   staging — trigger scan with baked image
 #   main — tag scanner:staging as scanner:production (zero rebuild)
 
-BRANCH="${CI_COMMIT_BRANCH}"
+BRANCH="${CI_COMMIT_BRANCH:-}"
+EVENT="${CI_PIPELINE_EVENT:-}"
 REGISTRY="${DOCKER_REGISTRY:?DOCKER_REGISTRY not set}"
 
-case "$BRANCH" in
+# #767: production triggers via GitHub Deployment API now (cross-repo rollout
+# #1187), not legacy `branch: main` push. Map event=deployment to "main".
+TARGET="$BRANCH"
+if [ "$EVENT" = "deployment" ]; then
+  TARGET="main"
+fi
+
+# #767: GitHub Deployment status callbacks for production deploys triggered
+# via the Deployment API. Best-effort.
+DEPLOYMENT_ID=""
+GH_API="https://api.github.com"
+GH_REPO="${CI_REPO:-Peregrine-Technology-Systems/peregrine-penetrator-scanner}"
+if [ "$EVENT" = "deployment" ] && [ -n "${GH_TOKEN:-}" ]; then
+  DEPLOY_REF="${CI_COMMIT_REF:-${CI_COMMIT_TAG:-${CI_COMMIT_SHA:-HEAD}}}"
+  DEPLOY_REF="${DEPLOY_REF#refs/tags/}"
+  DEPLOYMENT_ID=$(curl -sS -H "Authorization: Bearer ${GH_TOKEN}" \
+    -H "Accept: application/vnd.github+json" \
+    "${GH_API}/repos/${GH_REPO}/deployments?ref=${DEPLOY_REF}&per_page=1" \
+    2>/dev/null | jq -r '.[0].id // empty' 2>/dev/null || echo "")
+  if [ -n "$DEPLOYMENT_ID" ] && [ "$DEPLOYMENT_ID" != "null" ]; then
+    echo "Found Deployment id=${DEPLOYMENT_ID} for ref=${DEPLOY_REF}"
+  else
+    DEPLOYMENT_ID=""
+  fi
+fi
+
+post_deployment_status() {
+  [ -z "$DEPLOYMENT_ID" ] && return 0
+  [ -z "${GH_TOKEN:-}" ] && return 0
+  local state="$1" description="$2"
+  curl -sS -o /dev/null -X POST \
+    -H "Authorization: Bearer ${GH_TOKEN}" \
+    -H "Accept: application/vnd.github+json" \
+    -H "Content-Type: application/json" \
+    "${GH_API}/repos/${GH_REPO}/deployments/${DEPLOYMENT_ID}/statuses" \
+    -d "$(jq -n --arg s "$state" --arg d "$description" '{state: $s, description: $d, environment: "production"}')" \
+    || echo "Warning: Deployment status callback failed (state=$state)"
+}
+
+post_deployment_status "in_progress" "scanner deploy started"
+trap 'rc=$?; if [ "$rc" -ne 0 ]; then post_deployment_status "failure" "deploy.sh exited $rc"; fi' EXIT
+
+case "$TARGET" in
   staging)
     echo "=== Triggering staging scan with baked image ==="
     scripts/woodpecker/trigger-scan.sh staging standard
@@ -35,6 +78,10 @@ case "$BRANCH" in
     echo "scanner:production → ${STAGING_DIGEST}"
     ;;
   *)
-    echo "No deployment for branch: $BRANCH"
+    echo "No deployment for branch=$BRANCH event=$EVENT"
     ;;
 esac
+
+# #767: mark Deployment success and clear EXIT trap (no-op for non-deployment events)
+post_deployment_status "success" "scanner deploy completed (target=$TARGET)"
+trap - EXIT

--- a/scripts/woodpecker/version-bump.sh
+++ b/scripts/woodpecker/version-bump.sh
@@ -163,6 +163,30 @@ else
   cat /tmp/release-response.json
 fi
 
+# #767: fire GitHub Deployment API for the new tag (cross-repo rollout #1187).
+# Triggers release.yaml via the deployment webhook on event=deployment.
+# Best-effort — failure here doesn't block the release.
+echo "Firing GitHub Deployment for ${TAG} → triggers release.yaml via deployment webhook"
+DEPLOY_PAYLOAD=$(jq -n --arg ref "$TAG" --arg desc "Auto-deploy of ${TAG} triggered by main merge" '{
+  ref: $ref,
+  environment: "production",
+  auto_merge: false,
+  required_contexts: [],
+  description: $desc,
+  production_environment: true
+}')
+DEPLOY_RESPONSE=$(curl -sS -X POST -H "$AUTH" -H "Accept: application/vnd.github+json" \
+  -H "Content-Type: application/json" \
+  "${API}/repos/${REPO}/deployments" \
+  -d "$DEPLOY_PAYLOAD")
+DEPLOY_ID=$(echo "$DEPLOY_RESPONSE" | jq -r '.id // empty')
+if [ -n "$DEPLOY_ID" ] && [ "$DEPLOY_ID" != "null" ]; then
+  echo "Created Deployment id=${DEPLOY_ID} for ${TAG}"
+else
+  echo "WARNING: Deployment API call did not return an id — release.yaml may not fire"
+  echo "$DEPLOY_RESPONSE" | jq -r '.message // .' 2>/dev/null || echo "$DEPLOY_RESPONSE"
+fi
+
 # Tag Docker image by DIGEST: scanner:staging → scanner:vX.Y.Z + scanner:production
 # Using digest ensures the exact bytes that passed staging CI get promoted,
 # even if the staging tag was re-pointed by a concurrent build.


### PR DESCRIPTION
Cross-repo rollout #1187. Closes #767. See commit message for full details — note that scanner's production trigger lives in release.yaml, not deploy.yaml.

Reference impls: peregrine-grafana@f7507b4 (pilot), peregrine-monitoring@c80e0d3 (verified), peregrine-penetrator-front-end PR#677.

🤖 Generated with [Claude Code](https://claude.com/claude-code)