### PR TITLE
fix: remove tier:ondemand from non-production pipeline workflows

### DIFF
--- a/.woodpecker/ci.yaml
+++ b/.woodpecker/ci.yaml
@@ -7,7 +7,6 @@ when:
 labels:
   platform: linux
   backend: local
-  tier: ondemand
 
 steps:
   - name: check-release-notes


### PR DESCRIPTION
## Summary

Remove `tier: ondemand` from non-production pipeline workflows.

These pipelines were historically given `tier: ondemand` as a defensive workaround for spot VM agent-disconnect failures. That root cause is now fixed — see canonical policy: https://github.com/amalc/global-claude/pull/100

**Changed:**
- `ci.yaml` — removed `tier: ondemand`

Tracking: Peregrine-Technology-Systems/peregrine-ci-scaler#1175
🤖 Generated with [Claude Code](https://claude.com/claude-code)