### PR TITLE
ci: align workflows to global standards — drop backend:local, fix excludes + version-bump guards

### DIFF
--- a/.woodpecker/build-base.yaml
+++ b/.woodpecker/build-base.yaml
@@ -11,7 +11,6 @@ when:
 
 labels:
   platform: linux
-  backend: local
 
 steps:
   - name: build-base

--- a/.woodpecker/build.yaml
+++ b/.woodpecker/build.yaml
@@ -9,7 +9,6 @@ depends_on:
 
 labels:
   platform: linux
-  backend: local
 
 steps:
   - name: build

--- a/.woodpecker/ci.yaml
+++ b/.woodpecker/ci.yaml
@@ -1,12 +1,13 @@
-# Test & Lint — all branches except main (already tested on staging)
+# Test & Lint — all branches except main + promotion artifacts
+# (main is already tested on staging; merge/sync/release branches already
+# passed CI on their source branch — MUST HAVE Rule #2)
 when:
   - event: push
     branch:
-      exclude: main
+      exclude: [main, "merge/*", "sync/*", "release/*"]
 
 labels:
   platform: linux
-  backend: local
 
 steps:
   - name: check-release-notes

--- a/.woodpecker/deploy.yaml
+++ b/.woodpecker/deploy.yaml
@@ -8,7 +8,6 @@ depends_on:
 
 labels:
   platform: linux
-  backend: local
 
 steps:
   - name: deploy

--- a/.woodpecker/promote.yaml
+++ b/.woodpecker/promote.yaml
@@ -8,7 +8,6 @@ depends_on:
 
 labels:
   platform: linux
-  backend: local
 
 clone:
   - name: clone

--- a/.woodpecker/release.yaml
+++ b/.woodpecker/release.yaml
@@ -8,7 +8,6 @@ when:
 
 labels:
   platform: linux
-  backend: local
 
 steps:
   - name: promote-image

--- a/.woodpecker/smoke-test.yaml
+++ b/.woodpecker/smoke-test.yaml
@@ -9,7 +9,6 @@ depends_on:
 
 labels:
   platform: linux
-  backend: local
 
 steps:
   - name: smoke-test

--- a/.woodpecker/sync-back.yaml
+++ b/.woodpecker/sync-back.yaml
@@ -5,7 +5,6 @@ when:
 
 labels:
   platform: linux
-  backend: local
 
 clone:
   - name: clone

--- a/.woodpecker/version-bump.yaml
+++ b/.woodpecker/version-bump.yaml
@@ -5,7 +5,6 @@ when:
 
 labels:
   platform: linux
-  backend: local
 
 steps:
   - name: version-bump

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- ci: align workflows to current global standards — remove `backend: local` from all 9 `.woodpecker/*.yaml` workflows so steps route to the GCP agent fleet (`ci-agent@ci-runners-de`) instead of the bare d3ci42 droplet; this is the root cause of the persistent staging deploy/smoke-test failures since the fleet migration (#776, #781). `ci.yaml` now also excludes promotion-artifact branches (`merge/*`, `sync/*`, `release/*`) per MUST HAVE Rule #2. `version-bump.sh` guards are subject-anchored (`head -n1`) to avoid skipping a real release on a multi-line body match (identity v0.1.85 pattern), and gain loud drift detection (`exit 1`) when `## Unreleased` is empty while substantive commits exist (#776)
+
 - feat: decouple production deploy from merge — fire GitHub Deployment API as a separate step (#767, cross-repo rollout #1187). `.woodpecker/release.yaml`'s production trigger flipped from `event: push, branch: main` to `event: deployment`. Staging deploy (`.woodpecker/deploy.yaml`) unchanged. `version-bump.sh` POSTs to `/repos/.../deployments` after Release creation; `deploy.sh` updated to map `CI_PIPELINE_EVENT == deployment` to TARGET=main and posts `in_progress` / `success` / `failure` status callbacks against the Deployment record. `GH_TOKEN` added to release.yaml's promote-image step. Reference impl: peregrine-grafana@f7507b4 + peregrine-monitoring@c80e0d3 + peregrine-penetrator-front-end PR#677. Allowlist prerequisite (ci-infrastructure#1188) cleared 2026-04-26.
 
 - fix: `promote.sh` deletes stale remote merge branch before push — avoids non-fast-forward on close-and-retry (ci-infrastructure#1089)

--- a/scripts/woodpecker/version-bump.sh
+++ b/scripts/woodpecker/version-bump.sh
@@ -23,17 +23,22 @@ fi
 
 AUTH="Authorization: Bearer ${GH_TOKEN}"
 
-# Guard: skip version bump for automated commits (prevents infinite loop)
+# Guard: skip version bump for automated commits (prevents infinite loop).
+# Anchor on the SUBJECT line only (head -n1) — matching the full multi-line
+# message fires the guard on any merge commit whose body happens to contain
+# "release: v…" / "Sync:" on line 2+ (e.g. a PR body quoting a prior release
+# line), silently skipping a real release. Reference: identity v0.1.85 (#673).
 COMMIT_MSG="${CI_COMMIT_MESSAGE:-}"
-if echo "$COMMIT_MSG" | grep -qE '^release: v[0-9]'; then
+COMMIT_SUBJECT=$(printf '%s' "$COMMIT_MSG" | head -n 1)
+if echo "$COMMIT_SUBJECT" | grep -qE '^release: v[0-9]'; then
   echo "Skipping — version-bump commit (prevents loop)"
   exit 0
 fi
-if echo "$COMMIT_MSG" | grep -qiE '^Sync:|sync/version-|version files to'; then
+if echo "$COMMIT_SUBJECT" | grep -qiE '^Sync:|sync/version-|version files to'; then
   echo "Skipping — sync-back commit"
   exit 0
 fi
-if echo "$COMMIT_MSG" | grep -qE '^docs:|^docs\('; then
+if echo "$COMMIT_SUBJECT" | grep -qE '^docs:|^docs\('; then
   echo "Skipping — documentation-only commit"
   exit 0
 fi
@@ -67,6 +72,13 @@ if [ -z "$UNRELEASED_CONTENT" ]; then
     echo "Skipping — no unreleased content and no untagged content commits"
     exit 0
   fi
+  # Drift detection (MUST): ## Unreleased is empty BUT substantive commits exist
+  # since the last tag. A RELEASE_NOTES write was missed — fail loudly rather
+  # than silently tag an empty release. Silent-OK counterpart to the empty
+  # guard above (global standard: identity version-bump.sh lines 140-152).
+  echo "ERROR: ## Unreleased is empty but ${CONTENT_COMMITS} content commit(s) exist since ${LAST_TAG:-repo start}." >&2
+  echo "       RELEASE_NOTES.md was not updated for shipped work — refusing to tag an empty release." >&2
+  exit 1
 fi
 
 BUMP_TYPE="patch"


### PR DESCRIPTION
## What

Standards-alignment pass #1 (CI/CD routing & hygiene) ahead of the production run.

- **Remove `backend: local` from all 9 workflows.** Routed every step to the bare d3ci42 droplet instead of the GCP agent fleet. **This is the root cause of the persistent staging `deploy` + `smoke-test` failures** since the pentest-dev-vm fleet migration, and why PR #784 (staging→main) has been stuck ~3.5 weeks. Verified the fleet agent `ci-agent@ci-runners-de` already holds `compute.instanceAdmin.v1` + `artifactregistry.writer` + `secretmanager.secretAccessor` in `peregrine-pentest-dev`, so the scripts' ambient-cred auth works correctly once routed there — no SA-key secret needed. (#776, #781)
- **`ci.yaml` excludes `merge/*` `sync/*` `release/*`** in addition to `main` (MUST HAVE Rule #2 — promotion artifacts already passed CI on source).
- **`version-bump.sh` guards subject-anchored** (`head -n1`) — a multi-line body containing `release: v…`/`Sync:` on line 2+ no longer silently skips a real release (identity v0.1.85 pattern).
- **`version-bump.sh` drift detection** — `exit 1` (not a silent empty tag) when `## Unreleased` is empty while substantive commits exist (silent-OK counterpart to the empty-Unreleased guard).

## Why now

The user is bringing the repo in line with global standards before fixing debt and running to production. This PR removes the systemic routing bug that keeps the promote chain red.

## Testing

- `ruby -ryaml` parse of all 9 workflows — OK
- `bash -n version-bump.sh` — OK
- pre-commit: tests pass, coverage 94.08%

Refs #776, #781

🤖 Generated with [Claude Code](https://claude.com/claude-code)