### PR TITLE
ci: complete #767 decoupled production deploy + production smoke (#808)

### DIFF
--- a/.woodpecker/release.yaml
+++ b/.woodpecker/release.yaml
@@ -23,6 +23,23 @@ steps:
       - eval "$(/tmp/get-gh-token.sh)"
       - scripts/woodpecker/deploy.sh
 
+  # #808: production smoke — verify the promoted scanner:production actually runs
+  # (launches a smoke-test scan VM, asserts a fresh result in GCS). This is the
+  # production-side smoke that smoke-test.yaml could never run on main (it
+  # depends_on the staging-only deploy). A failure here marks the release failed.
+  - name: smoke-test
+    image: bash
+    environment:
+      GCP_PROJECT_DEV:
+        from_secret: gcp_project_dev
+      SLACK_WEBHOOK_URL:
+        from_secret: slack_webhook_url
+      NOTIFICATION_EMAIL:
+        from_secret: notification_email
+    commands:
+      - scripts/woodpecker/smoke-test.sh
+    depends_on: [promote-image]
+
   - name: notify-status
     image: bash
     environment:
@@ -32,4 +49,4 @@ steps:
       - scripts/woodpecker/notify-status.sh
     when:
       - status: [success, failure]
-    depends_on: [promote-image]
+    depends_on: [smoke-test]

--- a/.woodpecker/smoke-test.yaml
+++ b/.woodpecker/smoke-test.yaml
@@ -1,8 +1,10 @@
-# Post-deploy smoke test — staging and production only (dev uses interactive VM)
-# Triggers smoke-test profile: canned findings, stubbed reporter calls, validates GCS
+# Post-deploy smoke test — STAGING only (dev uses interactive VM).
+# Production smoke moved to release.yaml (#808): this workflow depends_on the
+# staging-only `deploy`, so it could never run on `main`. Production is now
+# smoke-verified by release.yaml on the GitHub Deployment event.
 when:
   - event: push
-    branch: [staging, main]
+    branch: staging
 
 depends_on:
   - deploy

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- ci: complete the #767 decoupled production deploy + production smoke (#808). Now that the `peregrine-ci-app` App token has `deployments: write` (infra#3514), `version-bump.sh`'s Deployment POST fires `release.yaml` (`event: deployment`), which retags `scanner:staging → scanner:production` (digest-verified) **and** runs a production smoke. `version-bump.sh` no longer retags `scanner:production` itself (release.yaml owns it). `smoke-test.sh` handles `event: deployment → main`; `smoke-test.yaml` is now staging-only (it depended on the staging-only `deploy`, so it could never smoke `main`). Production is finally smoke-verified on its own deploy, not just by byte-identity with staging (#808)
+
 ## v0.18.0 — 2026-06-09
 
 - chore: remove dead code + housekeeping — delete `dawn_scanner`/`dawn_parser` (and specs): wired into `SCANNER_MAP` but in no profile, and it audited the scanner's own gems (`dawn … Penetrator.root`) rather than the target, so it was both dead and architecturally wrong for a DAST tool. Delete the stale root `Dockerfile` (vestigial `rails new` scaffolding — the real image is `docker/Dockerfile`). Untrack + gitignore `spec/examples.txt` (RSpec persistence file that churned every run). Docs (README, ARCHITECTURE, DEVELOPMENT) updated. Also fix a `.githooks/pre-commit` bug: the best-effort local PDF-generation step (`generate-doc-pdf.sh` + the `[ -gt 0 ] && echo` guards) could return non-zero under `set -e`, silently aborting any commit that touched a real `.md` file. Made the whole block non-fatal with `|| true` (#799)

--- a/scripts/woodpecker/smoke-test.sh
+++ b/scripts/woodpecker/smoke-test.sh
@@ -5,7 +5,14 @@ set -euo pipefail
 # Uses 'smoke-test' profile: canned findings, stubbed reporter calls, validates full pipeline
 # Runs on staging and production only (development uses interactive VM)
 
-BRANCH="${CI_COMMIT_BRANCH}"
+BRANCH="${CI_COMMIT_BRANCH:-}"
+
+# #808: production smoke runs from release.yaml on the GitHub Deployment event.
+# On event=deployment CI_COMMIT_BRANCH is the tag (not "main"), so force main →
+# production, mirroring deploy.sh's tag/deployment detection (#767).
+if [ "${CI_PIPELINE_EVENT:-}" = "deployment" ] || [ -n "${CI_COMMIT_TAG:-}" ]; then
+  BRANCH="main"
+fi
 
 case "$BRANCH" in
   staging)     GCP_PROJECT="${GCP_PROJECT_DEV:?GCP_PROJECT_DEV not set}"; IMAGE_TAG="staging" ;;

--- a/scripts/woodpecker/version-bump.sh
+++ b/scripts/woodpecker/version-bump.sh
@@ -11,7 +11,8 @@ set -euo pipefail
 #    ## Unreleased above so future PRs have a target section
 # 4. Commit + tag
 # 5. Create GitHub Release with the notes body (every tag gets a Release)
-# 6. Tag Docker image (scanner:staging → scanner:vX.Y.Z + scanner:production)
+# 6. Tag Docker image for traceability (scanner:staging → scanner:vX.Y.Z).
+#    Production promotion is owned by release.yaml on the Deployment event (#808).
 
 REPO="Peregrine-Technology-Systems/peregrine-penetrator-scanner"
 API="https://api.github.com"
@@ -268,9 +269,11 @@ else
   echo "$DEPLOY_RESPONSE" | jq -r '.message // .' 2>/dev/null || echo "$DEPLOY_RESPONSE"
 fi
 
-# Tag Docker image by DIGEST: scanner:staging → scanner:vX.Y.Z + scanner:production
-# Using digest ensures the exact bytes that passed staging CI get promoted,
-# even if the staging tag was re-pointed by a concurrent build.
+# Tag the Docker image by DIGEST for version traceability: scanner:vX.Y.Z.
+# Production promotion (scanner:staging → scanner:production) is NOT done here.
+# It is owned by release.yaml on the GitHub Deployment event (#767/#808), so the
+# production deploy is decoupled, smoke-verified, and recorded as a Deployment.
+# The Deployment POST above fires that path.
 if [ -n "${DOCKER_REGISTRY:-}" ]; then
   gcloud auth configure-docker us-central1-docker.pkg.dev --quiet
 
@@ -279,25 +282,15 @@ if [ -n "${DOCKER_REGISTRY:-}" ]; then
     --format='value(image_summary.digest)' 2>/dev/null || echo "")
 
   if [ -n "$STAGING_DIGEST" ]; then
-    echo "Staging digest: ${STAGING_DIGEST}"
-
-    echo "Tagging scanner@${STAGING_DIGEST} as scanner:${TAG}"
+    echo "Tagging scanner@${STAGING_DIGEST} as scanner:${TAG} (version traceability)"
     gcloud artifacts docker tags add \
       "${DOCKER_REGISTRY}/scanner@${STAGING_DIGEST}" \
       "${DOCKER_REGISTRY}/scanner:${TAG}" 2>/dev/null || echo "WARNING: Could not tag scanner:${TAG}"
-
-    echo "Tagging scanner@${STAGING_DIGEST} as scanner:production"
-    gcloud artifacts docker tags add \
-      "${DOCKER_REGISTRY}/scanner@${STAGING_DIGEST}" \
-      "${DOCKER_REGISTRY}/scanner:production" 2>/dev/null || echo "WARNING: Could not tag scanner:production"
   else
-    echo "WARNING: Could not resolve staging digest — falling back to tag-based promotion"
+    echo "WARNING: Could not resolve staging digest — tagging scanner:${TAG} from the staging tag"
     gcloud artifacts docker tags add \
       "${DOCKER_REGISTRY}/scanner:staging" \
       "${DOCKER_REGISTRY}/scanner:${TAG}" 2>/dev/null || echo "WARNING: Could not tag scanner:${TAG}"
-    gcloud artifacts docker tags add \
-      "${DOCKER_REGISTRY}/scanner:staging" \
-      "${DOCKER_REGISTRY}/scanner:production" 2>/dev/null || echo "WARNING: Could not tag scanner:production"
   fi
 fi
 


### PR DESCRIPTION
## What

With the App token now granted `deployments: write` (infra#3514 ✅ — verified live: `deployments=write` on a fresh installation token), the #767 decoupled-deploy path can finally fire. This makes `release.yaml` the canonical production deploy+verify path.

- **`version-bump.sh`**: stop retagging `scanner:production` directly (keeps `scanner:vX.Y.Z` traceability tag + the Deployment POST, which now succeeds → fires `release.yaml`).
- **`release.yaml`**: add a **production smoke** step after `promote-image` (retag + digest verify). A smoke failure marks the release failed.
- **`smoke-test.sh`**: handle `event: deployment → main` (CI_COMMIT_BRANCH is the tag on deployment events).
- **`smoke-test.yaml`**: staging-only now — it `depends_on` the staging-only `deploy`, so it could never smoke `main`.

## Effect

Closes the production-smoke gap (#808 defect #1) and uses the now-working Deployment path (#808 defect #2). Production is smoke-verified on its **own** deploy, not just by byte-identity with staging.

## Validation plan

This PR is itself release-worthy, so its own promotion exercises the full decoupled path end-to-end: dev→staging→main → version-bump POSTs Deployment → `release.yaml` fires → retag + **production smoke**. I'll watch it live; the byte-identical hybrid model means production can at worst lag a version (never break) if the decoupled retag hiccups.

Closes #808

🤖 Generated with [Claude Code](https://claude.com/claude-code)