### PR TITLE
ci: migrate pipeline notifications to ci-events Pub/Sub (drop Slack) + fix prod-smoke env (#780, #808)

### DIFF
--- a/.woodpecker/build-base.yaml
+++ b/.woodpecker/build-base.yaml
@@ -23,9 +23,6 @@ steps:
 
   - name: notify-status
     image: bash
-    environment:
-      SLACK_WEBHOOK_URL:
-        from_secret: slack_webhook_url
     commands:
       - scripts/woodpecker/notify-status.sh
     when:

--- a/.woodpecker/build.yaml
+++ b/.woodpecker/build.yaml
@@ -21,9 +21,6 @@ steps:
 
   - name: notify-status
     image: bash
-    environment:
-      SLACK_WEBHOOK_URL:
-        from_secret: slack_webhook_url
     commands:
       - scripts/woodpecker/notify-status.sh
     when:

--- a/.woodpecker/ci.yaml
+++ b/.woodpecker/ci.yaml
@@ -35,9 +35,6 @@ steps:
 
   - name: notify-status
     image: bash
-    environment:
-      SLACK_WEBHOOK_URL:
-        from_secret: slack_webhook_url
     commands:
       - scripts/woodpecker/notify-status.sh
     when:

--- a/.woodpecker/deploy.yaml
+++ b/.woodpecker/deploy.yaml
@@ -15,16 +15,11 @@ steps:
     environment:
       DOCKER_REGISTRY:
         from_secret: docker_registry
-      SLACK_WEBHOOK_URL:
-        from_secret: slack_webhook_url
     commands:
       - scripts/woodpecker/deploy.sh
 
   - name: notify-status
     image: bash
-    environment:
-      SLACK_WEBHOOK_URL:
-        from_secret: slack_webhook_url
     commands:
       - scripts/woodpecker/notify-status.sh
     when:

--- a/.woodpecker/promote.yaml
+++ b/.woodpecker/promote.yaml
@@ -28,9 +28,6 @@ steps:
 
   - name: notify-status
     image: bash
-    environment:
-      SLACK_WEBHOOK_URL:
-        from_secret: slack_webhook_url
     commands:
       - scripts/woodpecker/notify-status.sh
     when:

--- a/.woodpecker/release.yaml
+++ b/.woodpecker/release.yaml
@@ -32,8 +32,6 @@ steps:
     environment:
       GCP_PROJECT_DEV:
         from_secret: gcp_project_dev
-      SLACK_WEBHOOK_URL:
-        from_secret: slack_webhook_url
       NOTIFICATION_EMAIL:
         from_secret: notification_email
     commands:
@@ -42,9 +40,6 @@ steps:
 
   - name: notify-status
     image: bash
-    environment:
-      SLACK_WEBHOOK_URL:
-        from_secret: slack_webhook_url
     commands:
       - scripts/woodpecker/notify-status.sh
     when:

--- a/.woodpecker/smoke-test.yaml
+++ b/.woodpecker/smoke-test.yaml
@@ -18,8 +18,6 @@ steps:
     environment:
       GCP_PROJECT_DEV:
         from_secret: gcp_project_dev
-      SLACK_WEBHOOK_URL:
-        from_secret: slack_webhook_url
       NOTIFICATION_EMAIL:
         from_secret: notification_email
     commands:

--- a/.woodpecker/sync-back.yaml
+++ b/.woodpecker/sync-back.yaml
@@ -25,9 +25,6 @@ steps:
 
   - name: notify-status
     image: bash
-    environment:
-      SLACK_WEBHOOK_URL:
-        from_secret: slack_webhook_url
     commands:
       - scripts/woodpecker/notify-status.sh
     when:

--- a/.woodpecker/version-bump.yaml
+++ b/.woodpecker/version-bump.yaml
@@ -12,8 +12,6 @@ steps:
     environment:
       DOCKER_REGISTRY:
         from_secret: docker_registry
-      SLACK_WEBHOOK_URL:
-        from_secret: slack_webhook_url
     commands:
       # GitHub App token (replaces static gh_token PAT) — peregrine-ci-app,
       # see peregrine-infrastructure/docs/operations/gh-app.md (#779)
@@ -24,9 +22,6 @@ steps:
 
   - name: notify-status
     image: bash
-    environment:
-      SLACK_WEBHOOK_URL:
-        from_secret: slack_webhook_url
     commands:
       - scripts/woodpecker/notify-status.sh
     when:

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- ci: migrate CI pipeline-status notifications to the ci-events Pub/Sub bus (bus-only-emit, ci-infra#1366) and drop Slack — Slack is deprecated (#780). `notify-status.sh` now publishes a `pipeline.status` CloudEvent to `ci-events` as `ci-agent@`; `SLACK_WEBHOOK_URL` removed from all 9 workflows; `version-bump.sh`'s direct Slack message removed. Also fixes the production-smoke env bug surfaced by #808: `smoke-test.sh` passed `$BRANCH` (`main`) to `trigger-scan.sh`, which expects an environment name → "Unknown environment: main"; now passes `IMAGE_TAG` (staging|production). App-level `SlackNotifier` runtime migration tracked as a follow-up (#780)
+
 ## v0.18.1 — 2026-06-09
 
 - ci: complete the #767 decoupled production deploy + production smoke (#808). Now that the `peregrine-ci-app` App token has `deployments: write` (infra#3514), `version-bump.sh`'s Deployment POST fires `release.yaml` (`event: deployment`), which retags `scanner:staging → scanner:production` (digest-verified) **and** runs a production smoke. `version-bump.sh` no longer retags `scanner:production` itself (release.yaml owns it). `smoke-test.sh` handles `event: deployment → main`; `smoke-test.yaml` is now staging-only (it depended on the staging-only `deploy`, so it could never smoke `main`). Production is finally smoke-verified on its own deploy, not just by byte-identity with staging (#808)

--- a/scripts/woodpecker/notify-status.sh
+++ b/scripts/woodpecker/notify-status.sh
@@ -1,74 +1,74 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Post pipeline status to Slack — runs on EVERY build
-# Highlights: failures (red), success (green/blue per environment)
-
-if [ -z "${SLACK_WEBHOOK_URL:-}" ]; then
-  echo "SLACK_WEBHOOK_URL not set, skipping notification"
-  exit 0
-fi
+# Post pipeline status to the ci-events Pub/Sub topic (bus-only-emit pattern,
+# ci-infrastructure#1366). Slack is deprecated — CI agents no longer call a
+# webhook directly. The monitoring droplet's forwarder subscribes to ci-events
+# and routes pipeline.status events downstream. Mirrors
+# peregrine-infrastructure/scripts/woodpecker/notify-status.sh (#780).
+#
+# Event type:  pipeline.status
+# Attributes:  event_type, severity, repo
+# Identity:    ci-agent@ci-runners-de (ambient on the GCP fleet agent)
 
 REPO_FULL="${CI_REPO:-unknown}"
-REPO="${REPO_FULL##*/}"  # Strip org prefix — just the repo name
+REPO="${REPO_FULL##*/}"
 BRANCH="${CI_COMMIT_BRANCH:-${CI_COMMIT_TAG:-unknown}}"
 COMMIT="${CI_COMMIT_SHA:0:7}"
 FULL_SHA="${CI_COMMIT_SHA:-}"
 AUTHOR="${CI_COMMIT_AUTHOR:-unknown}"
 MESSAGE="${CI_COMMIT_MESSAGE:-no message}"
 STATUS="${CI_PIPELINE_STATUS:-unknown}"
-WOODPECKER_URL="https://d3ci42.peregrinetechsys.net/repos/${CI_REPO_ID:-0}/pipeline/${CI_PIPELINE_NUMBER:-0}"
+PIPELINE_URL="https://d3ci42.peregrinetechsys.net/repos/${CI_REPO_ID:-0}/pipeline/${CI_PIPELINE_NUMBER:-0}"
 COMMIT_URL="https://github.com/${REPO_FULL}/commit/${FULL_SHA}"
-REPO_URL="https://github.com/${REPO_FULL}"
 
-# Truncate commit message to first line
+# Truncate commit message to the first line
 MESSAGE=$(echo "$MESSAGE" | head -1 | cut -c1-80)
 
-# Determine notification style — failure first, then environment-specific success
+VERSION=""
 if [ "$STATUS" = "failure" ]; then
-  EMOJI=":red_circle:"
-  COLOR="#dc3545"
-  TITLE="Pipeline FAILED"
+  SEVERITY="error"; EMOJI=":red_circle:"; COLOR="#dc3545"; TITLE="Pipeline FAILED"
 elif [ "$BRANCH" = "main" ] && [ -f VERSION ]; then
   VERSION=$(cat VERSION | tr -d '[:space:]')
-  EMOJI=":white_check_mark:"
-  COLOR="#28a745"
-  TITLE="Main passed (v${VERSION})"
+  SEVERITY="info"; EMOJI=":rocket:"; COLOR="#ffc107"; TITLE="PRODUCTION RELEASE v${VERSION}"
 elif [ "$BRANCH" = "staging" ]; then
-  EMOJI=":large_blue_circle:"
-  COLOR="#0d6efd"
-  TITLE="Staging passed"
+  SEVERITY="info"; EMOJI=":large_blue_circle:"; COLOR="#0d6efd"; TITLE="Staging passed"
 elif [ "$BRANCH" = "development" ]; then
-  EMOJI=":white_check_mark:"
-  COLOR="#28a745"
-  TITLE="Development passed"
+  SEVERITY="info"; EMOJI=":white_check_mark:"; COLOR="#28a745"; TITLE="Development passed"
 else
-  # Feature branches
-  EMOJI=":white_check_mark:"
-  COLOR="#6c757d"
-  TITLE="CI passed (${BRANCH})"
+  SEVERITY="info"; EMOJI=":white_check_mark:"; COLOR="#6c757d"; TITLE="CI passed (${BRANCH})"
 fi
 
-# Build the message — repo name linked, no org prefix
-DETAILS="*Branch:* ${BRANCH}\n*Commit:* <${COMMIT_URL}|\`${COMMIT}\`> — ${MESSAGE}\n*Author:* ${AUTHOR}"
+TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 
-# Standard notification for all builds (production celebration moved to deploy pipeline #367)
-curl -s -X POST "$SLACK_WEBHOOK_URL" \
-  -H "Content-Type: application/json" \
-  -d "{
-    \"text\": \"${EMOJI} ${TITLE} — ${REPO}\",
-    \"attachments\": [
-      {
-        \"color\": \"${COLOR}\",
-        \"blocks\": [
-          {
-            \"type\": \"section\",
-            \"text\": {
-              \"type\": \"mrkdwn\",
-              \"text\": \"${EMOJI} *${TITLE}* *<${REPO_URL}|${REPO}>*\n${DETAILS}\n<${WOODPECKER_URL}|View pipeline>\"
-            }
-          }
-        ]
-      }
-    ]
-  }" || echo "Warning: Slack notification failed"
+# Build JSON via python3 — commit messages can contain quotes/backticks; sys.argv
+# avoids shell-escaping gymnastics.
+PAYLOAD=$(python3 -c "
+import json, sys
+print(json.dumps({
+    'event_type':   'pipeline.status',
+    'timestamp':    sys.argv[1],
+    'repo':         sys.argv[2],
+    'repo_full':    sys.argv[3],
+    'branch':       sys.argv[4],
+    'commit':       sys.argv[5],
+    'commit_url':   sys.argv[6],
+    'author':       sys.argv[7],
+    'message':      sys.argv[8],
+    'status':       sys.argv[9],
+    'severity':     sys.argv[10],
+    'title':        sys.argv[11],
+    'emoji':        sys.argv[12],
+    'color':        sys.argv[13],
+    'version':      sys.argv[14],
+    'pipeline_url': sys.argv[15],
+}))
+" "$TIMESTAMP" "$REPO" "$REPO_FULL" "$BRANCH" "$COMMIT" "$COMMIT_URL" \
+  "$AUTHOR" "$MESSAGE" "$STATUS" "$SEVERITY" "$TITLE" "$EMOJI" "$COLOR" \
+  "$VERSION" "$PIPELINE_URL")
+
+gcloud pubsub topics publish ci-events \
+  --project=ci-runners-de \
+  --message="$PAYLOAD" \
+  --attribute="event_type=pipeline.status,severity=${SEVERITY},repo=${REPO}" \
+  || echo "WARN: Pub/Sub publish failed — notification lost"

--- a/scripts/woodpecker/smoke-test.sh
+++ b/scripts/woodpecker/smoke-test.sh
@@ -53,7 +53,10 @@ fi
 BEFORE=$(gsutil ls -r "${RESULTS_PREFIX}**/scan_results.json" 2>/dev/null | sort || echo "")
 
 # Launch a smoke-test scan VM (canned findings + stubbed reporter calls)
-scripts/woodpecker/trigger-scan.sh "${BRANCH}" smoke-test "${IMAGE_TAG}"
+# trigger-scan.sh's first arg is the ENVIRONMENT (development|staging|production),
+# not the branch. IMAGE_TAG is exactly that (staging|production), so pass it —
+# BRANCH=main would otherwise be "Unknown environment: main" (#808).
+scripts/woodpecker/trigger-scan.sh "${IMAGE_TAG}" smoke-test
 
 echo "Waiting up to ${MAX_WAIT}s for the smoke scan to publish a fresh result..."
 # The deploy step launches a long-running *standard* scan whose result may also

--- a/scripts/woodpecker/version-bump.sh
+++ b/scripts/woodpecker/version-bump.sh
@@ -294,35 +294,8 @@ if [ -n "${DOCKER_REGISTRY:-}" ]; then
   fi
 fi
 
-# Send an informational Slack notification for the tag — NOT a celebration.
-# The gold "PRODUCTION RELEASE" message should only fire after successful
-# deployment, which is handled by the deploy pipeline's notify-status.sh (#367)
-if [ -n "${SLACK_WEBHOOK_URL:-}" ]; then
-  COMMIT_URL="https://github.com/${REPO}/commit/$(git rev-parse HEAD)"
-  SHORT_SHA=$(git rev-parse --short HEAD)
-  WOODPECKER_URL="https://d3ci42.peregrinetechsys.net/repos/${CI_REPO_ID:-0}/pipeline/${CI_PIPELINE_NUMBER:-0}"
-  REPO_NAME="${REPO##*/}"
-  REPO_URL="https://github.com/${REPO}"
-
-  curl -s -X POST "$SLACK_WEBHOOK_URL" \
-    -H "Content-Type: application/json" \
-    -d "{
-      \"text\": \"Tagged ${TAG} — ${REPO_NAME} — deploying...\",
-      \"attachments\": [
-        {
-          \"color\": \"#6c757d\",
-          \"blocks\": [
-            {
-              \"type\": \"section\",
-              \"text\": {
-                \"type\": \"mrkdwn\",
-                \"text\": \":label: *Tagged ${TAG}* — *<${REPO_URL}|${REPO_NAME}>*\n*Bump:* ${BUMP_TYPE} (${CURRENT} → ${NEW_VERSION})\n*Commit:* <${COMMIT_URL}|\`${SHORT_SHA}\`>\n<${WOODPECKER_URL}|View pipeline>\"
-              }
-            }
-          ]
-        }
-      ]
-    }" || echo "Warning: Slack notification failed"
-fi
+# Pipeline-status notification (tag / release) is published to the ci-events
+# Pub/Sub topic by the notify-status step (#780); Slack is deprecated, so no
+# direct webhook call here.
 
 echo "=== Release ${TAG} complete ==="


### PR DESCRIPTION
## What

Two things, both surfaced by the first real fire of the decoupled `release.yaml` deploy:

### 1. Slack → Pub/Sub (#780) — Slack is deprecated
- `notify-status.sh` now publishes a `pipeline.status` CloudEvent to the **`ci-events` Pub/Sub topic** as `ci-agent@` (bus-only-emit, ci-infra#1366; mirrors `peregrine-infrastructure`'s reference). The monitoring forwarder routes it downstream.
- Removed `SLACK_WEBHOOK_URL` from **all 9 workflows** + `version-bump.sh`'s direct Slack message.
- Reverted the temporary `slack_webhook_url` secret-event change (nothing references it now).

### 2. Production-smoke env bug (#808)
The first `release.yaml` run failed with `Unknown environment: main`: `smoke-test.sh` passed `$BRANCH` (=`main` on a deployment event) to `trigger-scan.sh`, which expects an **environment** (`staging|production`). Now passes `IMAGE_TAG` (which is exactly `staging|production`).

## Validation

This PR's own promotion exercises the full path: dev→staging→main → version-bump → Deployment → `release.yaml` → retag + **production smoke** (now with the correct env) — and notifications go to Pub/Sub, not Slack. I'll watch it end-to-end.

## Follow-up
App-level `SlackNotifier`/`SlackAlert` (runtime scan notifications) migration tracked in #816.

Refs #780, #808

🤖 Generated with [Claude Code](https://claude.com/claude-code)