### PR TITLE
fix: harden promotion/release merge against async mergeability (#775)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix: harden promotion/release merge against GitHub async mergeability (#775). `version-bump.sh`'s mergeability poll now accepts `unstable` as well as `clean` — under Pattern A/B branch protection a non-required check (e.g. CodeQL on the release PR) never blocks the merge, so bailing on `unstable` stranded the release for a check that doesn't gate it (this is what stalled the v0.19.0 release and required a manual recovery). `promote.sh` replaces its single-shot `PUT /merge` — which printed "queued or waiting" and silently exit-0'd on failure, leaving PRs open with no clear error (a silent-OK, the original #775 report) — with the canonical poll (`clean`|`unstable`) + 3-attempt merge retry + fail-loud. Also fixes a `git commit --amend` in `promote.sh`'s Unreleased-dedup (global Rule #9 + ROBUST_PROMOTE_PATTERN.md forbid amend) → separate `chore:` commit. Pattern grounded in `~/.claude/docs/ROBUST_PROMOTE_PATTERN.md` (#775)
+
 - fix: Nikto severity driven from a stable key (test id / OSVDB id) via a maintained `config/nikto_severity_map.yml` lookup, with keyword inference as the unmapped fallback — and every fall-through to the `info` default is now logged (never silent). Closes the silent critical→info downgrade where a reworded upstream message (e.g. "Remote Code Execution" → "arbitrary OS operations") dropped a genuine critical to `info`. The shipped map starts empty (grown deliberately); the immediate behaviour change is observability of mis-maps + the mechanism to pin severities. Regression test asserts a known-critical stays critical via the stable key even when the message would infer `info` (positive broken-state counterpart) (#823)
 
 ## v0.19.0 — 2026-06-21

--- a/scripts/woodpecker/promote.sh
+++ b/scripts/woodpecker/promote.sh
@@ -119,7 +119,9 @@ if [ -f RELEASE_NOTES.md ]; then
   if [ "$DUPES" -gt 1 ]; then
     awk '!seen[$0]++ || !/^## Unreleased$/' RELEASE_NOTES.md > RELEASE_NOTES.tmp && mv RELEASE_NOTES.tmp RELEASE_NOTES.md
     git add RELEASE_NOTES.md
-    git commit --amend --no-edit
+    # Separate chore: commit — NEVER amend (global CLAUDE.md Rule #9 + the
+    # ROBUST_PROMOTE_PATTERN.md warning; the squash-free merge keeps it readable).
+    git commit -m "chore: dedup ## Unreleased headers (merge=union artifact)"
   fi
 fi
 
@@ -147,16 +149,42 @@ echo "Created PR #${PR_NUMBER}: ${PR_URL}"
 
 # ── Auto-merge or request reviewer ──
 if [ "$MODE" = "auto" ]; then
-  MERGE_RESULT=$(curl -s -X PUT -H "$AUTH" -H "Content-Type: application/json" \
-    "${API}/repos/${REPO}/pulls/${PR_NUMBER}/merge" \
-    -d '{"merge_method": "merge"}')
-  if echo "$MERGE_RESULT" | jq -e '.merged' > /dev/null 2>&1; then
-    echo "Auto-merged successfully"
-    # Clean up merge branch
-    curl -s -X DELETE -H "$AUTH" \
-      "${API}/repos/${REPO}/git/refs/heads/${MERGE_BRANCH}" > /dev/null 2>&1 || true
-  else
-    echo "Auto-merge queued or waiting for status checks"
+  # GitHub evaluates mergeability asynchronously — a PUT /merge on a brand-new PR
+  # returns 405/409 until the check resolves. Poll for it to settle, then merge
+  # with retry, then FAIL LOUD if it never lands. The old single-shot PUT printed
+  # "queued or waiting" and exit-0'd on failure — a silent-OK that left PRs open
+  # with no clear error and needed manual --admin merges (#775). Canonical poll +
+  # retry from ROBUST_PROMOTE_PATTERN.md. Accept clean|unstable (a non-required
+  # check pending/failing never blocks the merge); blocked/dirty/behind keep
+  # polling. The merge-branch flow is idempotent, so a failed run re-runs cleanly.
+  echo "Waiting for PR #${PR_NUMBER} to become mergeable..."
+  for i in $(seq 1 6); do
+    MERGE_STATE=$(curl -s -H "$AUTH" "${API}/repos/${REPO}/pulls/${PR_NUMBER}" \
+      | jq -r '.mergeable_state // "unknown"')
+    if [ "$MERGE_STATE" = "clean" ] || [ "$MERGE_STATE" = "unstable" ]; then break; fi
+    echo "  mergeability: ${MERGE_STATE} — retrying in 5s (attempt ${i}/6)"
+    sleep 5
+  done
+
+  MERGED=false
+  for ATTEMPT in 1 2 3; do
+    MERGE_RESULT=$(curl -s -X PUT -H "$AUTH" -H "Content-Type: application/json" \
+      "${API}/repos/${REPO}/pulls/${PR_NUMBER}/merge" \
+      -d '{"merge_method": "merge"}')
+    if echo "$MERGE_RESULT" | jq -e '.merged' > /dev/null 2>&1; then
+      MERGED=true
+      echo "Auto-merged successfully"
+      curl -s -X DELETE -H "$AUTH" \
+        "${API}/repos/${REPO}/git/refs/heads/${MERGE_BRANCH}" > /dev/null 2>&1 || true
+      break
+    fi
+    echo "Merge attempt ${ATTEMPT}/3 failed: $(echo "$MERGE_RESULT" | jq -r '.message // "?"')"
+    [ "$ATTEMPT" -lt 3 ] && sleep 5
+  done
+
+  if [ "$MERGED" = "false" ]; then
+    echo "ERROR: auto-merge failed after 3 attempts — PR #${PR_NUMBER} left open"
+    exit 1
   fi
 else
   REPO_OWNER=$(curl -s -H "$AUTH" "${API}/repos/${REPO}" | jq -r '.owner.login // empty')

--- a/scripts/woodpecker/version-bump.sh
+++ b/scripts/woodpecker/version-bump.sh
@@ -179,12 +179,21 @@ echo "Created release PR #${PR_NUMBER}"
 # GitHub computes .mergeable asynchronously (null while computing). Merging in
 # that window returns a misleading 409 "Base branch was modified". Poll up to
 # 30s for it to settle, then merge with up to 3 retries on that race only.
+#
+# Accept BOTH `clean` AND `unstable` (canonical ROBUST_PROMOTE_PATTERN.md poll):
+#   clean    = mergeable, all required checks green
+#   unstable = mergeable, required checks green, only a NON-required check
+#              pending/failing (e.g. CodeQL on the release PR)
+# Under Pattern A/B branch protection a non-required check never blocks the
+# merge, so bailing on `unstable` strands the release for a check that doesn't
+# gate it — the exact failure that stalled v0.19.0 (#775). `blocked`/`dirty`/
+# `behind` are NOT accepted and keep polling until the window expires.
 for attempt in $(seq 1 30); do
   PR_STATE=$(curl -s -H "$AUTH" "${API}/repos/${REPO}/pulls/${PR_NUMBER}")
   MERGEABLE=$(echo "$PR_STATE" | jq -r '.mergeable')
   MSTATE=$(echo "$PR_STATE" | jq -r '.mergeable_state')
-  if [ "$MERGEABLE" = "true" ] && [ "$MSTATE" = "clean" ]; then
-    echo "PR #${PR_NUMBER} mergeable after ${attempt}s"
+  if [ "$MERGEABLE" = "true" ] && { [ "$MSTATE" = "clean" ] || [ "$MSTATE" = "unstable" ]; }; then
+    echo "PR #${PR_NUMBER} mergeable after ${attempt}s (state=${MSTATE})"
     break
   fi
   if [ "$attempt" = "30" ]; then


### PR DESCRIPTION
## Summary

Closes #775. Hardens the promotion/release merge against GitHub's asynchronous mergeability evaluation — the bug that **stalled the v0.19.0 release** and the original #775 silent-failure report, fixed together since they're the same class. Grounded in the canonical `~/.claude/docs/ROBUST_PROMOTE_PATTERN.md`.

## The bug
GitHub reports `mergeable_state = unstable` when a PR is mergeable but a **non-required** check (e.g. CodeQL) is still pending/failing. Under this repo's **Pattern A** protection (no required checks), `unstable` is always safe to merge — but two scripts treated it as failure:

- **`version-bump.sh`** polled for `clean` **only** → a release PR sitting at `unstable` past 30s failed the release (stranded v0.19.0, manual recovery).
- **`promote.sh`** did a single-shot `PUT /merge` and printed `"queued or waiting"` + `exit 0` on failure — a **silent-OK** leaving PRs open with no error, needing manual `--admin` merges (the #775 report).

## Changes
- `version-bump.sh`: poll accepts `clean` **OR** `unstable`; `blocked`/`dirty`/`behind` keep polling.
- `promote.sh`: canonical poll (`clean`|`unstable`) + 3-attempt merge retry + **fail-loud** (`exit 1`) if it never lands. The merge-branch flow is idempotent, so a failed run re-runs cleanly.
- `promote.sh`: replace `git commit --amend` in the Unreleased-dedup with a separate `chore:` commit (global Rule #9 + the ROBUST_PROMOTE_PATTERN.md warning forbid amend).

## Audit (per #775)
Branch protection is **Pattern A** on all three branches (no required status checks — the global CLAUDE.md note listing this repo as Pattern B is stale; it migrated in v0.18.0). So `ci.yaml`'s exclude of `merge/*`/`sync/*`/`release/*` is correct, and the only non-ci statuses on promotion branches are CodeQL (non-required), now handled by accept-`unstable`. `MODE=auto` is dev→staging only; staging→main stays manual (Rule #9).

## Validation
`bash -n` + `shellcheck -S error` clean on both scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)