### PR TITLE
chore: sweep ci-infrastructure → peregrine-infrastructure references (#773)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ Report generation, AI analysis, ticketing, and email notifications have been ext
 
 ## Deploy Trigger Pattern
 
-Production deploy is **decoupled** from main-branch push via the GitHub Deployment API per cross-repo rollout peregrine-ci-infrastructure#1187 (this repo's adoption: #767). Production lives in `.woodpecker/release.yaml` (NOT `deploy.yaml` — that's staging). After main merge: `version-bump.yaml` runs → tag + Release → `version-bump.sh` POSTs `/repos/.../deployments` → GitHub deployment webhook → `release.yaml` fires on `event=deployment` → `deploy.sh` (TARGET=main path) promotes scanner:staging digest to scanner:production + posts in_progress/success/failure status callbacks. Staging deploy still triggers on `event: push, branch: staging`.
+Production deploy is **decoupled** from main-branch push via the GitHub Deployment API per cross-repo rollout peregrine-infrastructure#1187 (this repo's adoption: #767). Production lives in `.woodpecker/release.yaml` (NOT `deploy.yaml` — that's staging). After main merge: `version-bump.yaml` runs → tag + Release → `version-bump.sh` POSTs `/repos/.../deployments` → GitHub deployment webhook → `release.yaml` fires on `event=deployment` → `deploy.sh` (TARGET=main path) promotes scanner:staging digest to scanner:production + posts in_progress/success/failure status callbacks. Staging deploy still triggers on `event: push, branch: staging`.
 
 ## Build & Run Commands
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- chore: sweep stale `peregrine-ci-infrastructure` → `peregrine-infrastructure` references (#773). The repo was renamed; updated the two live citations — `CLAUDE.md` Deploy Trigger Pattern (`peregrine-ci-infrastructure#1187` → `peregrine-infrastructure#1187`) and `scripts/woodpecker/notify-status.sh` (`ci-infrastructure#1366` → `peregrine-infrastructure#1366`). Historical `## vX` RELEASE_NOTES citations left as-is (immutable history; editing them would dup headings under merge=union). (#773)
+
 - chore: unwind scanner-side production-scan scheduling (#829). Deleted the broken out-of-band `weekly-production-scan` Cloud Scheduler job (it 404'd every Monday — targeted `trigger-production-scan`, the real fn is `trigger-scan-production`; config captured before deletion). Removed the never-deployed legacy Cloud-Run-job model from Pulumi — the `pentest-scanner` `CloudRunV2::Job` + `pentest-scanner-schedule` `CloudScheduler::Job` + their `schedule`/`scan_profile` config (no Cloud Run Job was ever live). Production scan **scheduling is owned by the orchestrator** going forward (function-trigger model per infra ruling peregrine-infrastructure#3939); the `trigger-scan-*` Cloud Functions + `vm-scavenger` are retained (the orchestrator triggers scans via `trigger-scan-production`). #829 closed as superseded (#829)
 
 ## v0.19.3 — 2026-06-22

--- a/scripts/woodpecker/notify-status.sh
+++ b/scripts/woodpecker/notify-status.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 # Post pipeline status to the ci-events Pub/Sub topic (bus-only-emit pattern,
-# ci-infrastructure#1366). Slack is deprecated — CI agents no longer call a
+# peregrine-infrastructure#1366). Slack is deprecated — CI agents no longer call a
 # webhook directly. The monitoring droplet's forwarder subscribes to ci-events
 # and routes pipeline.status events downstream. Mirrors
 # peregrine-infrastructure/scripts/woodpecker/notify-status.sh (#780).


### PR DESCRIPTION
Closes #773. The repo was renamed; updated the two live citations (`CLAUDE.md` #1187 ref, `notify-status.sh` #1366 ref). Historical `## vX` RELEASE_NOTES citations left untouched (merge=union would dup headings). Verified: 0 non-RELEASE_NOTES `ci-infrastructure` refs remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)