### PR TITLE
fix: serialize target_urls list in trigger-scan Cloud Functions (#883)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix: serialize `target_urls` list before passing to `compute_v1.Items` in trigger-scan Cloud Functions (#883). When callers pass `"target_urls": [...]` as a JSON array, Flask's `get_json()` returns a Python list; the code only JSON-serialized when building from the singular `target_url` string. The list hit `compute_v1.Items(value=<list>)` and crashed with `TypeError: bad argument type for built-in operation`. Added `elif isinstance(target_urls, list): target_urls = json.dumps(target_urls)` branch + regression test. (#883)
+
 ## v0.21.0 — 2026-06-22
 
 - fix: rubocop autocorrects and Dockerfile.base tool install paths (#51, #50, #47). CI failure on development from PR #874 merge: 53 autocorrectable rubocop offenses across scan_orchestrator + new scanner/parser files. amass v5.1.1 ships as `.tar.gz` not `.zip`; retire.js (NodeSource) installs binary to `/usr/bin/retire` and modules to `/usr/lib/node_modules/` — not `/usr/local/` as originally coded in the COPY stage. (#51, #50, #47)

--- a/cloud/scheduler/main.py
+++ b/cloud/scheduler/main.py
@@ -425,6 +425,8 @@ def _trigger_scan(request, default_mode, default_tag):
             target_urls = target_url
         else:
             target_urls = json.dumps([target_url])
+    elif isinstance(target_urls, list):
+        target_urls = json.dumps(target_urls)
 
     timestamp = int(time.time())
     instance_name = f'pentest-scan-{scan_uuid[:8]}-{timestamp}'

--- a/cloud/scheduler/test_main.py
+++ b/cloud/scheduler/test_main.py
@@ -590,6 +590,28 @@ class TestTriggerProduction(unittest.TestCase):
 
     @patch('builtins.open', unittest.mock.mock_open(read_data='#!/bin/bash\necho hi'))
     @patch('main.compute_v1.InstancesClient')
+    def test_serializes_target_urls_list_to_json_string(self, mock_client_cls):
+        """target_urls passed as a Python list (from JSON body) must be serialized (#883)."""
+        client = MagicMock()
+        mock_client_cls.return_value = client
+        client.insert.return_value = MagicMock()
+
+        urls_list = ['https://a.com', 'https://b.com']
+        main.trigger_production(
+            _build_request('POST', '/', json_body={
+                'target_urls': urls_list,
+                'callback_url': 'https://orchestrator.example.com/callbacks',
+            }))
+
+        instance = client.insert.call_args.kwargs['request']['instance_resource']
+        metadata_dict = {
+            item.key: item.value for item in instance.metadata.items
+        }
+        self.assertIsInstance(metadata_dict['TARGET_URLS'], str)
+        self.assertEqual(metadata_dict['TARGET_URLS'], json.dumps(urls_list))
+
+    @patch('builtins.open', unittest.mock.mock_open(read_data='#!/bin/bash\necho hi'))
+    @patch('main.compute_v1.InstancesClient')
     def test_returns_json_content_type(self, mock_client_cls):
         client = MagicMock()
         mock_client_cls.return_value = client


### PR DESCRIPTION
## Summary

- Fixes HTTP 500 / `TypeError: bad argument type for built-in operation` when `target_urls` is passed as a JSON array to any `trigger-scan-*` Cloud Function
- Root cause: `compute_v1.Items` requires a string value; when callers pass `"target_urls": [...]` the list bypassed `json.dumps` and hit the Compute API raw
- Fix: one `elif isinstance(target_urls, list): target_urls = json.dumps(target_urls)` branch
- Added regression test `test_serializes_target_urls_list_to_json_string`

## Test plan

- [x] `pytest test_main.py -k "target_urls"` — both old + new test pass
- [ ] CI passes

Closes #883

🤖 Generated with [Claude Code](https://claude.com/claude-code)