### PR TITLE
feat: improve quick scan profile — testssl, nikto, tuned timeouts (#889)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- feat: improve quick scan profile — add testssl (TLS/SSL, 90s) and nikto (misconfig, 90s tuning=123b); move retire.js + trufflehog to parallel phase 1 with testssl; cut Nuclei timeout 300s→150s and raise rate 10→15 req/s to stop burning 5 min with 0 findings; ZAP delay halved 100ms→50ms. Expected wall time ~8 min vs ~6 min previously, but with meaningfully broader coverage. (#889)
 - fix: serialize `target_urls` list before passing to `compute_v1.Items` in trigger-scan Cloud Functions (#883). When callers pass `"target_urls": [...]` as a JSON array, Flask's `get_json()` returns a Python list; the code only JSON-serialized when building from the singular `target_url` string. The list hit `compute_v1.Items(value=<list>)` and crashed with `TypeError: bad argument type for built-in operation`. Added `elif isinstance(target_urls, list): target_urls = json.dumps(target_urls)` branch + regression test. (#883)
 
 ## v0.21.0 — 2026-06-22

--- a/config/scan_profiles/quick.yml
+++ b/config/scan_profiles/quick.yml
@@ -1,26 +1,33 @@
 name: quick
-description: "Fast baseline scan - ZAP baseline + Nuclei critical templates only"
+description: "Fast baseline scan - testssl + ZAP baseline + Nuclei + Nikto + retire.js + trufflehog (~10 min)"
 estimated_duration_minutes: 10
 rate_limit: 10
 phases:
   - name: discovery
-    tools: []
+    tools:
+      - tool: testssl
+        timeout: 90
+        severity: HIGH
+      - tool: retirejs
+        timeout: 90
+      - tool: trufflehog
+        timeout: 90
+    parallel: true
   - name: active_scan
     tools:
       - tool: zap
         mode: baseline
-        timeout: 300
-        delay_ms: 100
+        timeout: 240
+        delay_ms: 50
   - name: targeted
     tools:
       - tool: nuclei
         severity_filter: critical,high
-        timeout: 300
+        timeout: 150
         templates: []
-        rate_limit: 10
-        bulk_size: 5
-      - tool: retirejs
-        timeout: 180
-      - tool: trufflehog
-        timeout: 180
+        rate_limit: 15
+        bulk_size: 8
+      - tool: nikto
+        timeout: 90
+        tuning: "123b"
     parallel: true

--- a/spec/integration/e2e_scan_pipeline_spec.rb
+++ b/spec/integration/e2e_scan_pipeline_spec.rb
@@ -30,6 +30,14 @@ RSpec.describe 'E2E Scan Pipeline', :integration do # rubocop:disable RSpec/Desc
     allow(Scanners::NucleiScanner).to receive(:new).and_return(mock_nuclei)
     allow(mock_nuclei).to receive(:run).and_return({ success: true, findings: mock_findings[2..3] })
 
+    # Mock the additional tools added to the quick profile (testssl, retirejs, trufflehog, nikto)
+    [Scanners::TestsslScanner, Scanners::RetirejsScanner, Scanners::TrufflehogScanner,
+     Scanners::NiktoScanner].each do |klass|
+      mock_tool = instance_double(klass)
+      allow(klass).to receive(:new).and_return(mock_tool)
+      allow(mock_tool).to receive(:run).and_return({ success: true, findings: [] })
+    end
+
     # Mock storage (no GCS in tests)
     allow_any_instance_of(StorageService).to receive(:upload) # rubocop:disable RSpec/AnyInstance
 


### PR DESCRIPTION
## Summary

- **Add testssl** to quick profile (phase 1, parallel, 90s, HIGH severity) — TLS cert, weak ciphers, protocol versions, HSTS gaps. Fast and no-touch-the-app.
- **Add nikto** to quick profile (phase 3, parallel with Nuclei, 90s, tuning=123b) — common misconfig, interesting files, software ID.
- **Move retire.js + trufflehog to phase 1** (parallel with testssl) — they complete in 1–6s; no reason to wait for ZAP.
- **Cut Nuclei timeout 300s → 150s, rate 10 → 15** — ran full 300s with 0 findings in production; fail faster.
- **ZAP delay 100ms → 50ms** — was completing in 46s anyway.
- **Fix E2E spec** — add mocks for new quick profile tools (testssl, retirejs, trufflehog, nikto); previously only ZAP + Nuclei were mocked, causing SQLite BusyException on parallel phase 1 execution.

## Expected budget

```
Phase 1 (parallel): testssl 90s + retirejs + trufflehog  →  ~90s wall
Phase 2 (serial):   ZAP baseline, timeout 240s            →  ~50s wall (historically)
Phase 3 (parallel): Nuclei 150s + nikto 90s               → ~150s wall
Total max: ~490s / ~8 min — 2 min buffer
```

## Test plan

- [x] E2E spec passes (5 examples, 0 failures)
- [x] Pre-commit: tests pass at 94.52% coverage
- [x] `bundle exec rake scan:validate_profiles` — quick: valid (3 phases)
- [ ] CI passes

Closes #889

🤖 Generated with [Claude Code](https://claude.com/claude-code)