### PR TITLE
fix: SQLite WAL mode + busy_timeout for concurrent tool write safety (#892)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- fix: enable SQLite WAL mode + busy_timeout in `Penetrator.connect_db` to eliminate `SQLite3::BusyException` under concurrent tool writes (#892). `PRAGMA journal_mode=WAL` shrinks the write-commit window so concurrent writers rarely actually collide; `PRAGMA busy_timeout=5000` retries for up to 5s when they do. Default connection pool preserved — `max_connections: 1` would cause `Sequel::PoolTimeout` in parallel scan phases where each tool thread needs its own connection.
 - feat: improve quick scan profile — add testssl (TLS/SSL, 90s) and nikto (misconfig, 90s tuning=123b); move retire.js + trufflehog to parallel phase 1 with testssl; cut Nuclei timeout 300s→150s and raise rate 10→15 req/s to stop burning 5 min with 0 findings; ZAP delay halved 100ms→50ms. Expected wall time ~8 min vs ~6 min previously, but with meaningfully broader coverage. (#889)
 - fix: serialize `target_urls` list before passing to `compute_v1.Items` in trigger-scan Cloud Functions (#883). When callers pass `"target_urls": [...]` as a JSON array, Flask's `get_json()` returns a Python list; the code only JSON-serialized when building from the singular `target_url` string. The list hit `compute_v1.Items(value=<list>)` and crashed with `TypeError: bad argument type for built-in operation`. Added `elif isinstance(target_urls, list): target_urls = json.dumps(target_urls)` branch + regression test. (#883)
 

--- a/lib/penetrator.rb
+++ b/lib/penetrator.rb
@@ -44,7 +44,13 @@ module Penetrator
     def connect_db
       db_path = root.join('storage', "#{env}.sqlite3")
       FileUtils.mkdir_p(File.dirname(db_path))
+      # WAL mode: readers never block behind writers (write-commit window is tiny).
+      # busy_timeout: SQLite retries for up to 5s before raising BusyException when
+      # two threads happen to write simultaneously — the WAL window is small enough
+      # that retries almost always succeed within milliseconds.
       @db = Sequel.sqlite(db_path.to_s)
+      @db.run('PRAGMA journal_mode=WAL')
+      @db.run('PRAGMA busy_timeout=5000')
     end
 
     def migrate!

--- a/spec/penetrator_boot_spec.rb
+++ b/spec/penetrator_boot_spec.rb
@@ -37,5 +37,15 @@ RSpec.describe Penetrator do
     it 'has the findings table' do
       expect(described_class.db.table_exists?(:findings)).to be true
     end
+
+    it 'runs in WAL journal mode' do
+      mode = described_class.db.fetch('PRAGMA journal_mode').first[:journal_mode]
+      expect(mode).to eq('wal')
+    end
+
+    it 'has a 5-second busy timeout for SQLite-level write retry' do
+      timeout = described_class.db.fetch('PRAGMA busy_timeout').first[:timeout]
+      expect(timeout).to eq(5000)
+    end
   end
 end


### PR DESCRIPTION
## Summary

- Enables `PRAGMA journal_mode=WAL` on the SQLite connection at boot — WAL mode shrinks the write-commit window so parallel tool threads rarely collide on writes; readers never block behind writers
- Adds `PRAGMA busy_timeout=5000` — SQLite retries for up to 5s when two threads do happen to write simultaneously (WAL makes this rare; retries absorb the rest)
- Default Sequel connection pool preserved — `max_connections: 1` was tried first but caused `Sequel::PoolTimeout` in parallel scan phases where each tool thread needs its own connection object from the pool

## Why not `max_connections: 1`

Parallel phase execution (e.g. quick profile phase 1: testssl + retirejs + trufflehog) spawns N threads that each need a DB connection. With `max_connections: 1`, threads queue and hit Sequel's 5-second pool timeout (`Sequel::PoolTimeout`). WAL + busy_timeout achieves write safety without starving readers or causing pool exhaustion.

## Tests

- `runs in WAL journal mode` — `PRAGMA journal_mode` returns `wal`
- `has a 5-second busy timeout for SQLite-level write retry` — `PRAGMA busy_timeout` returns `5000`

## Test plan

- [x] `bundle exec rspec` — 634 examples, 0 failures, 94.53% coverage
- [ ] CI passes

Closes #892

🤖 Generated with [Claude Code](https://claude.com/claude-code)