### PR TITLE
fix: drop hand-rolled chruby activation; rely on agent BASH_ENV auto-select (#938)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,7 @@
 # Release Notes
 
 ## Unreleased
+- fix: drop the hand-rolled chruby activation in `test.sh`/`lint.sh` — rely on the agent's automatic ruby selection (#938). Per infra (#927), `/etc/chruby-ci.sh` is sourced via `BASH_ENV` on every CI step and runs `chruby "$(cat .ruby-version)"`; with `.ruby-version`=4.0.5 at repo root, 4.0.5 + bundler are already on PATH. The explicit blocks added in v1.0.0 sourced non-existent paths (`/opt/chruby/share/chruby/chruby.sh`) and never put ruby on PATH, failing native CI in ~1s. Removed; kept the `ruby -v` diagnostic echo. (#938)
 - docs: update README for the org-native cutover (#932) — drop Docker/DVWA/`cloud/dev` quickstart, ruby 3.2→4.0.5, replace the Docker Architecture + CI/CD sections with the org-native image model (baked `txn-scanner-app`, bake-on-tag, native CI) and the self-delete/reaper safety model, remove the reporter/backend system-context (one-component framing), drop the removed callback (#906), and add product context (Penetrator product line, SOC 2 Type II, cloud-agnostic). (#932)
 
 ## v1.0.0 — 2026-06-28

--- a/scripts/woodpecker/lint.sh
+++ b/scripts/woodpecker/lint.sh
@@ -21,17 +21,9 @@ for TARGET in development staging main; do
   fi
 done
 
-# Activate ruby 4.0.5 (see test.sh — the step shell doesn't auto-switch chruby).
-for cs in /opt/chruby/share/chruby/chruby.sh /usr/local/share/chruby/chruby.sh /etc/profile.d/chruby.sh; do
-  if [ -f "$cs" ]; then
-    # shellcheck disable=SC1090
-    . "$cs"; chruby ruby-4.0.5 2>/dev/null || chruby 4.0.5 2>/dev/null || true
-    break
-  fi
-done
-for rd in /opt/rubies/4.0.5/bin /opt/rubies/ruby-4.0.5/bin; do
-  if [ -x "$rd/ruby" ]; then export PATH="$rd:$PATH"; break; fi
-done
+# Ruby is auto-selected by the agent via BASH_ENV (/etc/chruby-ci.sh runs
+# `chruby "$(cat .ruby-version)"`); .ruby-version=4.0.5 → no explicit activation
+# needed (infra #927, see test.sh). Echo for diagnostics.
 echo "==> Ruby: $(ruby -v)"
 bundle install --jobs 4 --retry 3
 bundle exec rubocop --parallel

--- a/scripts/woodpecker/test.sh
+++ b/scripts/woodpecker/test.sh
@@ -27,19 +27,10 @@ for TARGET in development staging main; do
   fi
 done
 
-# Activate ruby 4.0.5 — the non-interactive Woodpecker step shell does not
-# auto-switch chruby on .ruby-version, so activate it explicitly (chruby source,
-# else the chruby rubies dir on PATH). Agent rubies live in /opt/rubies (infra).
-for cs in /opt/chruby/share/chruby/chruby.sh /usr/local/share/chruby/chruby.sh /etc/profile.d/chruby.sh; do
-  if [ -f "$cs" ]; then
-    # shellcheck disable=SC1090
-    . "$cs"; chruby ruby-4.0.5 2>/dev/null || chruby 4.0.5 2>/dev/null || true
-    break
-  fi
-done
-for rd in /opt/rubies/4.0.5/bin /opt/rubies/ruby-4.0.5/bin; do
-  if [ -x "$rd/ruby" ]; then export PATH="$rd:$PATH"; break; fi
-done
+# Ruby is selected automatically by the agent: /etc/chruby-ci.sh is sourced via
+# BASH_ENV on every CI step and runs `chruby "$(cat .ruby-version)"` against the
+# checkout root. We ship .ruby-version=4.0.5, so 4.0.5 + bundler are already on
+# PATH here — no explicit activation needed (infra #927). Echo for diagnostics.
 echo "==> Ruby: $(ruby -v)"
 bundle install --jobs 4 --retry 3
 APP_ENV=test bundle exec rspec --format documentation


### PR DESCRIPTION
Closes #938.

Native CI was red: `test.sh`/`lint.sh` hand-rolled chruby activation sourcing **non-existent** paths (`/opt/chruby/share/chruby/chruby.sh`), so ruby/bundler never landed on PATH and the step failed in ~1s.

Per infra (#927): the agent sources `/etc/chruby-ci.sh` via `BASH_ENV` on every CI step and runs `chruby "$(cat .ruby-version)"`. We ship `.ruby-version`=4.0.5, so ruby 4.0.5 + bundler are already active — the explicit blocks were redundant and wrong. Removed them; kept the `ruby -v` diagnostic echo.

This is the last CI-side item of the org-native cutover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)