### PR TITLE
docs: README — document reduced profile + baked tool set, refresh badges (#940)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,12 @@
 
 <!-- Badges -->
 [![Woodpecker CI](https://d3ci42.peregrinetechsys.net/api/badges/5/status.svg)](https://d3ci42.peregrinetechsys.net/repos/5) <!-- allow-sensitive: public Woodpecker CI server (serves the status badge) -->
+![Release](https://img.shields.io/badge/release-v1.0.0-blue)
 ![Ruby](https://img.shields.io/badge/ruby-4.0.5-CC342D?logo=ruby&logoColor=white)
 ![Sequel](https://img.shields.io/badge/ORM-Sequel-blue)
-![Coverage](https://img.shields.io/badge/coverage-93%25+-brightgreen)
+![Coverage](https://img.shields.io/badge/coverage-94%25+-brightgreen)
 ![RuboCop](https://img.shields.io/badge/rubocop-0%20offenses-brightgreen)
+![Image](https://img.shields.io/badge/image-txn--scanner--app%20(baked%20GCE)-success)
 ![License](https://img.shields.io/badge/license-BSL%201.1-blue)
 ![Platform](https://img.shields.io/badge/platform-GCP-4285F4?logo=googlecloud&logoColor=white)
 
@@ -86,13 +88,19 @@ For the full architecture reference, see [docs/ARCHITECTURE.md](docs/ARCHITECTUR
 
 ## Security Tool Stack
 
-| Tool | Phase | Purpose |
-|------|-------|---------|
-| **OWASP ZAP** | Active | Full DAST scanning |
-| **Nuclei** | Targeted | Template-based CVE scanning (11,000+ templates) |
-| **sqlmap** | Targeted | SQL injection detection |
-| **ffuf** | Discovery | Directory/endpoint enumeration |
-| **Nikto** | Discovery | Server misconfiguration detection |
+| Tool | Phase | Purpose | Baked in `txn-scanner-app` |
+|------|-------|---------|:--:|
+| **OWASP ZAP** | Active | Full DAST scanning | ✅ |
+| **Nuclei** | Targeted | Template-based CVE scanning (11,000+ templates) | ✅ |
+| **testssl.sh** | Discovery | TLS/SSL configuration analysis | ✅ |
+| **trufflehog** | Targeted | Hardcoded secret / credential detection | ✅ |
+| **sqlmap** | Targeted | SQL injection detection | — |
+| **ffuf** | Discovery | Directory/endpoint enumeration | — |
+| **Nikto** | Discovery | Server misconfiguration detection | — |
+| **retire.js** | Targeted | Vulnerable JS library detection | — |
+| **amass** | Discovery | Subdomain enumeration | — |
+
+> The **`reduced`** profile (below) is the org-native production profile today: it uses **only the baked tool set** (testssl + ZAP baseline + Nuclei + trufflehog). The remaining tools (`—`) are wired into the codebase and the fuller profiles, pending the bakery vendoring their apt/npm dependencies into the image.
 
 ---
 
@@ -127,12 +135,15 @@ SCAN_PROFILE=standard TARGET_NAME="My App" TARGET_URLS='["https://example.com"]'
 
 | Profile | Duration | Discovery | Active | Targeted |
 |---------|----------|-----------|--------|----------|
+| `reduced` | ~25 min | testssl | ZAP baseline | Nuclei + trufflehog | 
 | `quick` | ~10 min | -- | ZAP baseline | Nuclei critical/high |
 | `standard` | ~30 min | ffuf + Nikto | ZAP full | Nuclei + sqlmap |
 | `thorough` | ~2 hr | ffuf + Nikto | ZAP full (deep) | All tools |
 | `deep` | ~2 hr | (alias for `thorough`) | Same | Same |
 | `smoke` | <30s | -- | -- | Infra validation (tools, GCS, secrets) |
 | `smoke-test` | <30s | -- | -- | Canned findings for deploy verification |
+
+> **`reduced` is the current org-native production profile** — its tool set matches exactly what is baked into `txn-scanner-app` (see [Security Tool Stack](#security-tool-stack)). The other profiles describe the full design intent; they become runnable on the baked image as the remaining tools are vendored in.
 
 ---
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,7 @@
 # Release Notes
 
 ## Unreleased
+- docs: README — document the `reduced` profile + baked tool set, refresh badges (#940). Adds `reduced` to the Scan Profiles table (flagged as the current org-native production profile — its tools match what's baked into `txn-scanner-app`); adds a "Baked in txn-scanner-app" column to the Security Tool Stack and the four missing tools (testssl, trufflehog, retire.js, amass); bumps the coverage badge 93%→94%+ (actual 94.36%) and adds `release v1.0.0` + baked-image badges. Docs-only. (#940)
 - fix: drop the hand-rolled chruby activation in `test.sh`/`lint.sh` — rely on the agent's automatic ruby selection (#938). Per infra (#927), `/etc/chruby-ci.sh` is sourced via `BASH_ENV` on every CI step and runs `chruby "$(cat .ruby-version)"`; with `.ruby-version`=4.0.5 at repo root, 4.0.5 + bundler are already on PATH. The explicit blocks added in v1.0.0 sourced non-existent paths (`/opt/chruby/share/chruby/chruby.sh`) and never put ruby on PATH, failing native CI in ~1s. Removed; kept the `ruby -v` diagnostic echo. (#938)
 - docs: update README for the org-native cutover (#932) — drop Docker/DVWA/`cloud/dev` quickstart, ruby 3.2→4.0.5, replace the Docker Architecture + CI/CD sections with the org-native image model (baked `txn-scanner-app`, bake-on-tag, native CI) and the self-delete/reaper safety model, remove the reporter/backend system-context (one-component framing), drop the removed callback (#906), and add product context (Penetrator product line, SOC 2 Type II, cloud-agnostic). (#932)
 


### PR DESCRIPTION
Closes #940.

Post-cutover README accuracy fixes (docs-only):
- **Scan Profiles**: add `reduced` (the org-native production profile — tools match the baked image) + a note distinguishing it from the fuller design-intent profiles.
- **Security Tool Stack**: add a "Baked in `txn-scanner-app`" column and the four missing tools (testssl, trufflehog, retire.js, amass) from `SCANNER_MAP`.
- **Badges**: coverage 93%→94%+ (actual 94.36%), add `release v1.0.0` + baked-image badges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)