### PR TITLE
docs: reflect the tenth probe (API fuzz) + black-box/no-auth policy (#1022)

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,8 +94,11 @@ For the full architecture reference, see [docs/ARCHITECTURE.md](docs/ARCHITECTUR
 | **Nikto** | Discovery | Server misconfiguration detection | — |
 | **retire.js** | Targeted | Vulnerable JS library detection | — |
 | **amass** | Discovery | Subdomain enumeration | — |
+| **schemathesis** | API Fuzz | Unauthenticated, schema-driven API fuzzing — auto-discovers a *publicly reachable* OpenAPI/GraphQL schema and fuzzes every operation it declares | — |
 
 > The **`reduced`** profile (below) is the org-native production profile today: it uses **only the baked tool set** (testssl + ZAP baseline + Nuclei + trufflehog). The remaining tools (`—`) are wired into the codebase and the fuller profiles, pending the bakery vendoring their apt/npm dependencies into the image.
+
+> **Testing posture — black-box, unauthenticated (policy).** Every probe runs against the target exactly as an unauthenticated external party would see it. The scanner performs **no authenticated testing** — no provisioned credentials, no login, no access-control (BOLA/IDOR) testing. This is a deliberate scope choice. Even the API-fuzz probe stays inside the boundary: it *discovers* a publicly reachable schema (a schema URL is data, not a credential) and reports **not-applicable** when none is reachable, rather than logging in. See [docs/probe_categories.md](docs/probe_categories.md).
 
 ---
 
@@ -211,6 +214,7 @@ CI runs on [Woodpecker CI](https://d3ci42.peregrinetechsys.net) (self-hosted). <
 | [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) | Full architecture with Mermaid diagrams — scan flow, control plane, VM lifecycle, data model, reliability |
 | [docs/SECURITY_ARCHITECTURE.md](docs/SECURITY_ARCHITECTURE.md) | Threat model, secrets management, container/network/control plane security |
 | [docs/probe_contract.md](docs/probe_contract.md) | **Canonical probe output contract** — the finding shape this probe emits for downstream analysis |
+| [docs/probe_categories.md](docs/probe_categories.md) | **Probe taxonomy** — the ten probes grouped by type of testing, and the black-box / no-authenticated-testing posture |
 | [docs/schema_versioning.md](docs/schema_versioning.md) | JSON envelope version contract + MINOR/MAJOR evolution rules |
 | [docs/data_retention_policy.md](docs/data_retention_policy.md) | Data retention: scanner retains nothing; downstream deletes scan records post-delivery; only a minimal audit record (18mo, SOC 2) is kept |
 | [docs/audit_logging.md](docs/audit_logging.md) | Audit event types, chain of custody, compliance (SOC 2, ISO 27001) |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -226,11 +226,19 @@ flowchart LR
         N1 ---|parallel| S1
     end
 
+    subgraph "Phase 4: API Fuzz"
+        direction TB
+        A1["SchemathesisScanner<br/>Unauthenticated, schema-driven<br/>API fuzzing (auto-discovered schema)"]
+    end
+
     F1 & F2 --> Z1
     Z1 --> N1 & S1
+    N1 & S1 --> A1
 ```
 
-Discovered URLs from Phase 1 are fed into subsequent phases, expanding the scan surface.
+Discovered URLs from Phase 1 are fed into subsequent phases, expanding the scan surface. The diagrams above show a representative subset of the fleet's **ten probes**; the full set and the tool→phase mapping live in the `thorough` profile (`config/scan_profiles/thorough.yml`) and [docs/probe_categories.md](probe_categories.md).
+
+**Black-box, unauthenticated by policy.** No phase authenticates to the target — every probe runs as an unauthenticated external party would. The **API-fuzz** phase stays inside that boundary: `SchemathesisScanner` *discovers* a publicly reachable OpenAPI/GraphQL schema (a schema URL is data, not a credential) and is honestly **not-applicable** — empty findings, logged — when no schema is reachable without logging in, rather than fabricating a pass.
 
 ---
 

--- a/docs/SECURITY_ARCHITECTURE.md
+++ b/docs/SECURITY_ARCHITECTURE.md
@@ -16,7 +16,7 @@ title: Security Architecture
 
 ## Threat Model
 
-This addresses risks to the scanning engine. The engine executes offensive security tooling against authorized target URLs and produces vulnerability findings. Notably, it operates with a **minimal secret surface**: it performs **unauthenticated** scanning (it holds no target credentials), and its CVE-enrichment lookups run **without an API key**.
+This addresses risks to the scanning engine. The engine executes offensive security tooling against authorized target URLs and produces vulnerability findings. Notably, it operates with a **minimal secret surface**: it performs **black-box, unauthenticated** scanning **as a matter of policy** — it holds no target credentials and never logs in. It also holds **no third-party API keys**: CVE/exploit enrichment is a downstream concern (removed from this engine in the thin-probe cutover), so no NVD-style key is provisioned here. Even the API-fuzz probe stays inside the boundary — it *discovers* a publicly reachable schema (a schema URL is data, not a credential) rather than authenticating.
 
 ### Assets
 
@@ -27,8 +27,9 @@ This addresses risks to the scanning engine. The engine executes offensive secur
 | Source code | Low/Medium | Public repository (intentionally — see below). |
 
 **Not assets for this engine (common misconceptions):**
-- **Target credentials** — the engine scans **unauthenticated**; it does not log in to targets and stores no target credentials. (A latent `auth_config` schema field exists but is **not used** by any scanner.)
-- **Tool/CVE API keys** — CVE enrichment runs **keyless**; no NVD (or similar) API key is provisioned or held.
+- **Target credentials** — the engine scans **black-box / unauthenticated as a matter of policy**; it does not log in to targets, performs no authenticated or access-control (BOLA/IDOR) testing, and stores no target credentials. (A latent `auth_config` schema field exists but is **not used** by any scanner.) This shrinks the blast radius: a compromised scanner VM leaks no target logins because it never held any.
+- **API schemas are not credentials** — the API-fuzz probe (schemathesis) discovers a *publicly reachable* OpenAPI/GraphQL schema and reports **not-applicable** when none is reachable unauthenticated; it never authenticates to obtain one.
+- **Tool/CVE API keys** — no third-party API key is provisioned or held; CVE/exploit enrichment is downstream, out of scope for this engine.
 
 ### Threat Actors
 


### PR DESCRIPTION
## What

Refreshes the repo docs for this session's changes — the tenth probe (schemathesis / unauthenticated API fuzzing, #1018/#1020) and the black-box, no-authenticated-testing **policy**.

## Changes
- **README.md** — schemathesis row in the tools table (API Fuzz; not yet baked); a black-box/unauthenticated **testing-posture** note; docs-table link to `probe_categories.md`.
- **docs/ARCHITECTURE.md** — Phase 4 (API Fuzz / `SchemathesisScanner`) added to the phase-execution diagram; notes the fleet is **ten probes** and black-box by policy (schema discovery ≠ authentication; not-applicable when no unauthenticated schema is reachable).
- **docs/SECURITY_ARCHITECTURE.md** — threat model reframed from *"holds no target credentials"* to **"black-box / unauthenticated as a matter of policy"**; adds that API schemas are data, not credentials; **fixes a stale claim** — the doc still described keyless *CVE-enrichment lookups*, but enrichment was removed from this engine in the thin-probe cutover (v1.2.0), so it now correctly states no third-party API keys are held.

Docs-only; no code or behavior change.

Closes #1022.

🤖 Generated with [Claude Code](https://claude.com/claude-code)